### PR TITLE
Update publish scripts for stable releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.14.1"
+version = "0.14.3"
 authors = [
   "CyberHoward <cyberhoward@protonmail.com>",
   "Riada <riada@abstract.money>",
@@ -77,13 +77,13 @@ manager = { package = "abstract-manager", path = "contracts/account/manager" }
 osmosis-host = { path = "contracts/ibc-hosts/osmosis" }
 abstract-ibc-client = { package = "abstract-ibc-client", path = "contracts/native/ibc-client" }
 
-abstract-sdk = { version = "0.14.1", path = "packages/abstract-sdk" }
-abstract-testing = { version = "0.14.1", path = "packages/abstract-testing" }
-abstract-core = { version = "0.14.1", path = "packages/abstract-core" }
+abstract-sdk = { version = "0.14.3", path = "packages/abstract-sdk" }
+abstract-testing = { version = "0.14.3", path = "packages/abstract-testing" }
+abstract-core = { version = "0.14.3", path = "packages/abstract-core" }
 
 # These should remain fixed and don't need to be re-published (unless changes are made)
-abstract-macros = { version = "0.14.1", path = "packages/abstract-macros" }
-abstract-ica = { version = "0.14.1", path = "packages/abstract-ica" }
+abstract-macros = { version = "0.14.3", path = "packages/abstract-macros" }
+abstract-ica = { version = "0.14.3", path = "packages/abstract-ica" }
 
 ## Testing
 cw-multi-test = { version = "0.16.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ abstract-app = { path = "packages/abstract-app" }
 
 # Keep these as path, creates cirular dependency otherwise
 # Only need to re-publish all contracts if a re-publish of abstract-boot is required
+#abstract-boot = { path = "packages/abstract-boot", version = "0.14.3" }
 abstract-boot = { path = "packages/abstract-boot" }
 module-factory = { package = "abstract-module-factory", path = "contracts/native/module-factory" }
 account-factory = { package = "abstract-account-factory", path = "contracts/native/account-factory" }

--- a/packages/abstract-api/Cargo.toml
+++ b/packages/abstract-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-api"
-version = "0.14.1"
+version = "0.14.3"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
@@ -30,7 +30,7 @@ abstract-core = { workspace = true }
 abstract-testing = { workspace = true, optional = true }
 boot-core = { workspace = true, optional = true }
 # Keep this as a version and update when publishing new versions
-abstract-boot = { version = "0.14.1", workspace = true, optional = true }
+abstract-boot = { version = "0.14.3", workspace = true, optional = true }
 
 [dev-dependencies]
 speculoos = { workspace = true }

--- a/packages/abstract-app/Cargo.toml
+++ b/packages/abstract-app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "abstract-app"
-version = "0.14.1"
+version = "0.14.3"
 edition = { workspace = true }
 license = { workspace = true }
 description = "base app contract implementation"
@@ -30,7 +30,7 @@ abstract-core = { workspace = true }
 abstract-testing = { workspace = true, optional = true }
 boot-core = { workspace = true, optional = true }
 # Keep this as a version and update when publishing new versions
-abstract-boot = { version = "0.14.1", workspace = true, optional = true }
+abstract-boot = { version = "0.14.3", workspace = true, optional = true }
 
 [dev-dependencies]
 cosmwasm-schema = { workspace = true }

--- a/packages/abstract-boot/Cargo.toml
+++ b/packages/abstract-boot/Cargo.toml
@@ -37,9 +37,9 @@ serde_json = "1.0.79"
 speculoos = { workspace = true }
 
 # Keep these here
-module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.14.1", optional = true }
-account-factory = { package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false, version = "0.14.1", optional = true }
-ans-host = { package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false, version = "0.14.1", optional = true }
-version-control = { package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false, version = "0.14.1", optional = true }
-proxy = { package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false, version = "0.14.1", optional = true }
-manager = { package = "abstract-manager", path = "../../contracts/account/manager", default-features = false, version = "0.14.1", optional = true }
+module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.14.3", optional = true }
+account-factory = { package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false, version = "0.14.3", optional = true }
+ans-host = { package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false, version = "0.14.3", optional = true }
+version-control = { package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false, version = "0.14.3", optional = true }
+proxy = { package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false, version = "0.14.3", optional = true }
+manager = { package = "abstract-manager", path = "../../contracts/account/manager", default-features = false, version = "0.14.3", optional = true }

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -18,7 +18,7 @@ BASE_PACKAGES="abstract-ica abstract-macros"
 UTILS_PACKAGES="abstract-core abstract-testing abstract-sdk"
 CORE_CONTRACTS="proxy manager"
 NATIVE_CONTRACTS="ans-host account-factory module-factory version-control"
-ALL_PACKAGES="abstract-boot abstract-api abstract-app abstract-ibc-host"
+ALL_PACKAGES="abstract-boot"
 
  for pack in $BASE_PACKAGES; do
    (

--- a/publish/publish2.sh
+++ b/publish/publish2.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# This is the second in line to publish the abstract packages. Chceck the base [`Cargo.toml`] and uncomment the version of `abstract-boot`.
+set -o errexit -o nounset -o pipefail
+command -v shellcheck >/dev/null && shellcheck "$0"
+
+function print_usage() {
+  echo "Usage: $0 [-h|--help]"
+  echo "Publishes crates to crates.io."
+}
+
+if [ $# = 1 ] && { [ "$1" = "-h" ] || [ "$1" = "--help" ] ; }
+then
+    print_usage
+    exit 1
+fi
+
+ALL_PACKAGES="abstract-api abstract-app abstract-ibc-host"
+
+for pack in $ALL_PACKAGES; do
+  (
+    cd "packages/$pack"
+    echo "Publishing $pack"
+    cargo publish
+  )
+done
+
+echo "Everything is published!"
+
+VERSION=$(grep -A1 "\[workspace.package\]" Cargo.toml | awk -F'"' '/version/ {print $2}');
+git tag v"$VERSION"
+git push origin v"$VERSION"


### PR DESCRIPTION
This change updates to 0.14.3 and also splits the publish scripts into two separate files. This is because the framework packages require `abstract-boot` to be versioned, which requires manual intervention as of now.
