### PR TITLE
Additional tests for abstract-core

### DIFF
--- a/packages/abstract-core/src/ibc_host.rs
+++ b/packages/abstract-core/src/ibc_host.rs
@@ -149,3 +149,39 @@ pub struct AccountInfo {
     pub account: String,
     pub channel_id: String,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use abstract_testing::prelude::*;
+    use speculoos::prelude::*;
+
+    #[test]
+    fn test_into_packet() {
+        // Create an instance of HostAction (assuming a valid variant is `SomeAction`)
+        let host_action = HostAction::SendAllBack {};
+
+        // Create required parameters
+        let retries = 5u8;
+        let client_chain = String::from("test_client_chain");
+        let callback_info = Some(CallbackInfo {
+            id: "15".to_string(),
+            receiver: "receiver".to_string(),
+        });
+
+        // Call into_packet function
+        let packet_msg = host_action.clone().into_packet(
+            TEST_ACCOUNT_ID,
+            retries,
+            client_chain.clone(),
+            callback_info.clone(),
+        );
+
+        // Check if the returned PacketMsg has the expected values
+        assert_that!(packet_msg.client_chain).is_equal_to(client_chain);
+        assert_that!(packet_msg.retries).is_equal_to(retries);
+        assert_that!(packet_msg.callback_info).is_equal_to(callback_info);
+        assert_that!(packet_msg.account_id).is_equal_to(TEST_ACCOUNT_ID);
+        assert_that!(packet_msg.action).is_equal_to(host_action);
+    }
+}

--- a/packages/abstract-core/src/native/ibc_client.rs
+++ b/packages/abstract-core/src/native/ibc_client.rs
@@ -181,6 +181,7 @@ pub struct AccountInfo {
 }
 
 impl AccountInfo {
+    /// Use the provided *channel_id* and *account_id* to create a new [`AccountInfo`] based off of the provided *input* [`AccountData`].
     pub fn convert(channel_id: String, account_id: AccountId, input: AccountData) -> Self {
         AccountInfo {
             channel_id,
@@ -209,5 +210,79 @@ impl From<AccountData> for AccountResponse {
             remote_addr: input.remote_addr,
             remote_balance: input.remote_balance,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use abstract_testing::prelude::*;
+    use cosmwasm_std::to_binary;
+    use speculoos::prelude::*;
+
+    // ... (other test functions)
+
+    #[test]
+    fn test_account_info_convert() {
+        let channel_id = "channel-123".to_string();
+        let input = AccountData {
+            last_update_time: Default::default(),
+            remote_addr: None,
+            remote_balance: vec![],
+        };
+
+        let expected = AccountInfo {
+            channel_id: channel_id.clone(),
+            account_id: TEST_ACCOUNT_ID,
+            last_update_time: input.clone().last_update_time,
+            remote_addr: input.clone().remote_addr,
+            remote_balance: input.clone().remote_balance,
+        };
+
+        let actual = AccountInfo::convert(channel_id.clone(), TEST_ACCOUNT_ID, input.clone());
+
+        assert_that!(actual).is_equal_to(expected);
+    }
+
+    #[test]
+    fn test_account_response_from() {
+        let input = AccountData::default();
+
+        let expected = AccountResponse {
+            last_update_time: input.clone().last_update_time,
+            remote_addr: input.clone().remote_addr,
+            remote_balance: input.clone().remote_balance,
+        };
+
+        let actual = AccountResponse::from(input.clone());
+
+        assert_that!(actual).is_equal_to(expected);
+    }
+
+    #[test]
+    fn test_callback_info_to_callback_msg() {
+        let receiver = "receiver".to_string();
+        let callback_id = "15".to_string();
+        let callback_info = CallbackInfo {
+            id: callback_id.clone(),
+            receiver: receiver.clone(),
+        };
+        let ack_data = &to_binary(&StdAck::Result(to_binary(&true).unwrap())).unwrap();
+
+        let actual = callback_info.to_callback_msg(&ack_data.clone()).unwrap();
+
+        let funds: Vec<Coin> = vec![];
+
+        assert_that!(actual).matches(|e| {
+            matches!(
+                e,
+                CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Execute {
+                    contract_addr: receiver,
+                    // we can't test the message because the fields in it are private
+                    msg: _,
+                    funds
+                })
+            )
+        });
     }
 }

--- a/packages/abstract-core/src/native/ibc_client.rs
+++ b/packages/abstract-core/src/native/ibc_client.rs
@@ -234,12 +234,12 @@ mod tests {
         let expected = AccountInfo {
             channel_id: channel_id.clone(),
             account_id: TEST_ACCOUNT_ID,
-            last_update_time: input.clone().last_update_time,
+            last_update_time: input.last_update_time,
             remote_addr: input.clone().remote_addr,
             remote_balance: input.clone().remote_balance,
         };
 
-        let actual = AccountInfo::convert(channel_id.clone(), TEST_ACCOUNT_ID, input.clone());
+        let actual = AccountInfo::convert(channel_id, TEST_ACCOUNT_ID, input);
 
         assert_that!(actual).is_equal_to(expected);
     }
@@ -249,12 +249,12 @@ mod tests {
         let input = AccountData::default();
 
         let expected = AccountResponse {
-            last_update_time: input.clone().last_update_time,
+            last_update_time: input.last_update_time,
             remote_addr: input.clone().remote_addr,
             remote_balance: input.clone().remote_balance,
         };
 
-        let actual = AccountResponse::from(input.clone());
+        let actual = AccountResponse::from(input);
 
         assert_that!(actual).is_equal_to(expected);
     }
@@ -264,23 +264,23 @@ mod tests {
         let receiver = "receiver".to_string();
         let callback_id = "15".to_string();
         let callback_info = CallbackInfo {
-            id: callback_id.clone(),
-            receiver: receiver.clone(),
+            id: callback_id,
+            receiver: receiver,
         };
         let ack_data = &to_binary(&StdAck::Result(to_binary(&true).unwrap())).unwrap();
 
         let actual = callback_info.to_callback_msg(&ack_data.clone()).unwrap();
 
-        let funds: Vec<Coin> = vec![];
+        let _funds: Vec<Coin> = vec![];
 
         assert_that!(actual).matches(|e| {
             matches!(
                 e,
                 CosmosMsg::Wasm(cosmwasm_std::WasmMsg::Execute {
-                    contract_addr: receiver,
+                    contract_addr: _receiver,
                     // we can't test the message because the fields in it are private
                     msg: _,
-                    funds
+                    funds: _
                 })
             )
         });

--- a/packages/abstract-core/src/objects/asset_entry.rs
+++ b/packages/abstract-core/src/objects/asset_entry.rs
@@ -222,12 +222,12 @@ mod test {
         assert_that!(entry.src_chain())
             .is_err()
             .is_equal_to(AbstractError::EntryFormattingError {
-                actual: input.to_ascii_lowercase().to_string(),
+                actual: input.to_ascii_lowercase(),
                 expected: "src_chain>asset_name".to_string(),
             });
         assert_that!(entry.asset_name()).is_err().is_equal_to(
             AbstractError::EntryFormattingError {
-                actual: input.to_ascii_lowercase().to_string(),
+                actual: input.to_ascii_lowercase(),
                 expected: "src_chain>asset_name".to_string(),
             },
         );

--- a/packages/abstract-core/src/objects/asset_entry.rs
+++ b/packages/abstract-core/src/objects/asset_entry.rs
@@ -1,3 +1,4 @@
+use crate::{AbstractError, AbstractResult};
 use cosmwasm_std::StdResult;
 use cw_storage_plus::{Key, KeyDeserialize, Prefixer, PrimaryKey};
 use schemars::JsonSchema;
@@ -6,7 +7,8 @@ use std::fmt::Display;
 
 pub const CHAIN_DELIMITER: &str = ">";
 
-/// May key to retrieve information on an asset
+/// An unchecked ANS asset entry. This is a string that is formatted as
+/// `src_chain>[intermediate_chain>]asset_name`
 #[derive(
     Deserialize, Serialize, Clone, Debug, PartialEq, Eq, JsonSchema, PartialOrd, Ord, Default,
 )]
@@ -26,22 +28,56 @@ impl AssetEntry {
     /// Retrieve the source chain of the asset
     /// Example: osmosis>juno>crab returns osmosis
     /// Returns string to remain consistent with [`Self::asset_name`]
-    pub fn src_chain(&self) -> String {
-        self.0
-            .split(CHAIN_DELIMITER)
-            .next()
-            .unwrap_or("")
-            .to_string()
+    pub fn src_chain(&self) -> AbstractResult<String> {
+        let mut split = self.0.splitn(2, CHAIN_DELIMITER);
+
+        match split.next() {
+            Some(src_chain) => {
+                if src_chain.is_empty() {
+                    return self.entry_formatting_error();
+                }
+                // Ensure there's at least one more element (asset_name)
+                let maybe_asset_name = split.next();
+                if maybe_asset_name.is_some() && maybe_asset_name != Some("") {
+                    Ok(src_chain.to_string())
+                } else {
+                    self.entry_formatting_error()
+                }
+            }
+            None => self.entry_formatting_error(),
+        }
     }
 
     /// Retrieve the asset name without the src chain
     /// Example: osmosis>juno>crab returns juno>crab
-    pub fn asset_name(&self) -> String {
-        self.0
-            .split(CHAIN_DELIMITER)
-            .skip(1)
-            .collect::<Vec<&str>>()
-            .join(CHAIN_DELIMITER)
+    pub fn asset_name(&self) -> AbstractResult<String> {
+        let mut split = self.0.splitn(2, CHAIN_DELIMITER);
+
+        // Check if the first part (src_chain) exists
+        let first = split.next();
+        if first.is_none() || first == Some("") {
+            return self.entry_formatting_error();
+        }
+
+        // Check if the second part (asset_name) exists
+        let second = split.next();
+        match second {
+            Some(asset_name) => {
+                if asset_name.is_empty() {
+                    self.entry_formatting_error()
+                } else {
+                    Ok(asset_name.to_string())
+                }
+            }
+            None => self.entry_formatting_error(),
+        }
+    }
+
+    fn entry_formatting_error(&self) -> AbstractResult<String> {
+        Err(AbstractError::EntryFormattingError {
+            actual: self.0.clone(),
+            expected: "src_chain>asset_name".to_string(),
+        })
     }
 }
 
@@ -102,6 +138,7 @@ impl KeyDeserialize for &AssetEntry {
 #[cfg(test)]
 mod test {
     use super::*;
+    use rstest::rstest;
     use speculoos::prelude::*;
 
     #[test]
@@ -110,6 +147,90 @@ mod test {
         assert_that!(entry.as_str()).is_equal_to("crab");
         entry.format();
         assert_that!(entry.as_str()).is_equal_to("crab");
+    }
+
+    #[test]
+    fn test_src_chain() -> AbstractResult<()> {
+        // technically invalid, but we don't care here
+        let entry = AssetEntry::new("CRAB");
+        assert_that!(entry.src_chain())
+            .is_err()
+            .is_equal_to(AbstractError::EntryFormattingError {
+                actual: "crab".to_string(),
+                expected: "src_chain>asset_name".to_string(),
+            });
+        let entry = AssetEntry::new("osmosis>crab");
+        assert_that!(entry.src_chain())
+            .is_ok()
+            .is_equal_to("osmosis".to_string());
+        let entry = AssetEntry::new("osmosis>juno>crab");
+        assert_that!(entry.src_chain())
+            .is_ok()
+            .is_equal_to("osmosis".to_string());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_asset_name() -> AbstractResult<()> {
+        let entry = AssetEntry::new("CRAB");
+        assert_that!(entry.asset_name()).is_err().is_equal_to(
+            AbstractError::EntryFormattingError {
+                actual: "crab".to_string(),
+                expected: "src_chain>asset_name".to_string(),
+            },
+        );
+        let entry = AssetEntry::new("osmosis>crab");
+        assert_that!(entry.asset_name())
+            .is_ok()
+            .is_equal_to("crab".to_string());
+        let entry = AssetEntry::new("osmosis>juno>crab");
+        assert_that!(entry.asset_name())
+            .is_ok()
+            .is_equal_to("juno>crab".to_string());
+
+        Ok(())
+    }
+
+    #[rstest]
+    #[case("osmosis>crab", "osmosis", "crab")]
+    #[case("osmosis>juno>crab", "osmosis", "juno>crab")]
+    #[case("terra>osmosis>juno>crab", "terra", "osmosis>juno>crab")]
+    fn test_src_chain_and_asset_name(
+        #[case] input: &str,
+        #[case] expected_src_chain: &str,
+        #[case] expected_asset_name: &str,
+    ) {
+        let entry = AssetEntry::new(input);
+
+        assert_that!(entry.src_chain())
+            .is_ok()
+            .is_equal_to(expected_src_chain.to_string());
+        assert_that!(entry.asset_name())
+            .is_ok()
+            .is_equal_to(expected_asset_name.to_string());
+    }
+
+    #[rstest]
+    #[case("CRAB")]
+    #[case("")]
+    #[case(">")]
+    #[case("juno>")]
+    fn test_src_chain_and_asset_name_error(#[case] input: &str) {
+        let entry = AssetEntry::new(input);
+
+        assert_that!(entry.src_chain())
+            .is_err()
+            .is_equal_to(AbstractError::EntryFormattingError {
+                actual: input.to_ascii_lowercase().to_string(),
+                expected: "src_chain>asset_name".to_string(),
+            });
+        assert_that!(entry.asset_name()).is_err().is_equal_to(
+            AbstractError::EntryFormattingError {
+                actual: input.to_ascii_lowercase().to_string(),
+                expected: "src_chain>asset_name".to_string(),
+            },
+        );
     }
 
     #[test]

--- a/packages/abstract-core/src/objects/lp_token.rs
+++ b/packages/abstract-core/src/objects/lp_token.rs
@@ -11,6 +11,7 @@ pub type DexName = String;
 
 /// A key for the token that represents Liquidity Pool shares on a dex
 /// @todo: move into dex package
+/// Will be formatted as "dex_name/asset1,asset2" when serialized
 #[derive(
     Deserialize, Serialize, Clone, Debug, PartialEq, Eq, JsonSchema, PartialOrd, Ord, Default,
 )]
@@ -43,7 +44,7 @@ impl TryFrom<AssetEntry> for LpToken {
 
         if segments.len() != 2 {
             return Err(StdError::generic_err(format!(
-                "Invalid asset entry: {asset}"
+                "Invalid LP token asset entry: {asset}"
             )));
         }
 

--- a/packages/abstract-core/src/objects/price_source.rs
+++ b/packages/abstract-core/src/objects/price_source.rs
@@ -9,11 +9,6 @@
 //! The base asset is the asset for which `price_source` in `None`.
 //! **There should only be ONE base asset when configuring your proxy**
 
-use super::{
-    ans_host::AnsHost, asset_entry::AssetEntry, DexAssetPairing, LpToken, PoolAddress,
-    PoolReference,
-};
-use crate::{error::AbstractError, AbstractResult};
 use cosmwasm_std::{
     to_binary, Addr, Decimal, Deps, QuerierWrapper, QueryRequest, StdError, Uint128, WasmQuery,
 };
@@ -21,9 +16,17 @@ use cw_asset::{Asset, AssetInfo};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::{error::AbstractError, AbstractResult};
+
+use super::{
+    ans_host::AnsHost, asset_entry::AssetEntry, DexAssetPairing, LpToken, PoolAddress,
+    PoolReference,
+};
+
 /// represents the conversion of an asset in terms of the provided asset
 /// Example: provided asset is ETH and the price source for ETH is the pair ETH/USD, the price is 100USD/ETH
 /// then `AssetConversion { into: USD, ratio: 100}`
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
 pub struct AssetConversion {
     into: AssetInfo,
     ratio: Decimal,
@@ -98,6 +101,7 @@ impl UncheckedPriceSource {
                 let pairing = DexAssetPairing::try_from(token_entry)?;
                 let pool_assets = ans_host.query_assets(&deps.querier, &lp_token.assets)?;
                 // TODO: fix this for multiple pools with same pair
+                // TODO: don't use unwrap
                 let pool_address = ans_host
                     .query_asset_pairing(&deps.querier, &pairing)?
                     .pop()
@@ -215,7 +219,7 @@ impl PriceSource {
         &self,
         deps: Deps,
         lp_asset: &AssetInfo,
-        pool: &Addr,
+        pool_addr: &Addr,
         pool_assets: &[AssetInfo],
     ) -> AbstractResult<Vec<AssetConversion>> {
         let supply: Uint128;
@@ -226,13 +230,13 @@ impl PriceSource {
         }
         pool_assets
             .iter()
-            .map(|a| {
-                let balance = a
-                    .query_balance(&deps.querier, pool.clone())
+            .map(|asset| {
+                let pool_balance = asset
+                    .query_balance(&deps.querier, pool_addr.clone())
                     .map_err(AbstractError::from)?;
                 Ok(AssetConversion::new(
-                    a.clone(),
-                    Decimal::from_ratio(balance.u128(), supply.u128()),
+                    asset.clone(),
+                    Decimal::from_ratio(pool_balance.u128(), supply.u128()),
                 ))
             })
             .collect::<AbstractResult<Vec<AssetConversion>>>()
@@ -246,4 +250,185 @@ fn query_cw20_supply(querier: &QuerierWrapper, contract_addr: &Addr) -> Abstract
             msg: to_binary(&cw20::Cw20QueryMsg::TokenInfo {})?,
         }))?;
     Ok(response.total_supply)
+}
+
+#[cfg(test)]
+mod tests {
+    use abstract_testing::prelude::*;
+    use cosmwasm_std::testing::mock_dependencies;
+    use speculoos::prelude::*;
+
+    use super::*;
+
+    // TODO: abstract_testing has a circular dependency with this package, and so the mockAns host is unable to be used.
+    mod check {
+        use crate::ans_host;
+        use cosmwasm_std::testing::mock_dependencies;
+
+        use crate::objects::pool_id::PoolAddressBase;
+
+        use super::*;
+
+        #[test]
+        fn liquidity_token() -> AbstractResult<()> {
+            let mut deps = mock_dependencies();
+            // we cannot use the MockAnsHost because it has a circular dependency with this package
+            deps.querier = MockQuerierBuilder::default()
+                .with_contract_map_entries(
+                    TEST_ANS_HOST,
+                    ans_host::state::ASSET_ADDRESSES,
+                    vec![
+                        (
+                            &AssetEntry::from(TEST_ASSET_1),
+                            AssetInfo::native(TEST_ASSET_1),
+                        ),
+                        (
+                            &AssetEntry::from(TEST_ASSET_2),
+                            AssetInfo::native(TEST_ASSET_2),
+                        ),
+                    ],
+                )
+                .with_contract_map_entries(
+                    TEST_ANS_HOST,
+                    ans_host::state::ASSET_PAIRINGS,
+                    vec![(
+                        &DexAssetPairing::new(TEST_ASSET_1.into(), TEST_ASSET_2.into(), TEST_DEX),
+                        vec![PoolReference::new(
+                            TEST_UNIQUE_ID.into(),
+                            PoolAddressBase::Contract(Addr::unchecked(TEST_POOL_ADDR)),
+                        )],
+                    )],
+                )
+                .build();
+
+            let price_source = UncheckedPriceSource::LiquidityToken {};
+
+            let actual_source_res = price_source.check(
+                deps.as_ref(),
+                &AnsHost::new(Addr::unchecked(TEST_ANS_HOST)),
+                &AssetEntry::new(TEST_LP_TOKEN_NAME),
+            );
+
+            assert_that!(actual_source_res)
+                .is_ok()
+                .is_equal_to(PriceSource::LiquidityToken {
+                    pool_address: PoolAddress::contract(Addr::unchecked(TEST_POOL_ADDR)),
+                    pool_assets: vec![
+                        AssetInfo::native(TEST_ASSET_1),
+                        AssetInfo::native(TEST_ASSET_2),
+                    ],
+                });
+            Ok(())
+        }
+
+        #[test]
+        fn liquidity_token_missing_asset() -> AbstractResult<()> {
+            let mut deps = mock_dependencies();
+            deps.querier = MockQuerierBuilder::default()
+                .with_contract_map_key(
+                    TEST_ANS_HOST,
+                    ans_host::state::ASSET_ADDRESSES,
+                    &TEST_ASSET_1.into(),
+                )
+                .with_contract_map_key(
+                    TEST_ANS_HOST,
+                    ans_host::state::ASSET_ADDRESSES,
+                    &TEST_ASSET_2.into(),
+                )
+                .with_contract_map_entries(TEST_ANS_HOST, ans_host::state::ASSET_PAIRINGS, vec![])
+                .build();
+
+            let price_source = UncheckedPriceSource::LiquidityToken {};
+
+            let actual_source_res = price_source.check(
+                deps.as_ref(),
+                &AnsHost::new(Addr::unchecked(TEST_ANS_HOST)),
+                &AssetEntry::new(TEST_LP_TOKEN_NAME),
+            );
+
+            assert_that!(actual_source_res)
+                .is_err()
+                .is_equal_to(AbstractError::Std(StdError::generic_err(format!(
+                    "asset {} not found in ans_host",
+                    TEST_ASSET_1
+                ))));
+            Ok(())
+        }
+    }
+
+    mod lp_conversion {
+        use super::*;
+
+        #[test]
+        fn fail_with_native_token() -> AbstractResult<()> {
+            let deps = mock_dependencies();
+            let price_source = PriceSource::LiquidityToken {
+                pool_address: PoolAddress::contract(Addr::unchecked(TEST_POOL_ADDR)),
+                pool_assets: vec![AssetInfo::native(TEST_ASSET_1)],
+            };
+            let actual_res = price_source.lp_conversion(
+                deps.as_ref(),
+                &AssetInfo::native("aoeu"),
+                &Addr::unchecked(TEST_POOL_ADDR),
+                &[],
+            );
+            assert_that!(actual_res)
+                .is_err()
+                .is_equal_to(AbstractError::Std(StdError::generic_err(
+                    "Can't have a native LP token",
+                )));
+            Ok(())
+        }
+
+        #[test]
+        fn gets_cw20_supply() -> AbstractResult<()> {
+            let mut deps = mock_dependencies();
+            deps.querier = MockQuerierBuilder::default()
+                .with_contract_item(
+                    TEST_LP_TOKEN_ADDR,
+                    cw20_base::state::TOKEN_INFO,
+                    &cw20_base::state::TokenInfo {
+                        name: "test".to_string(),
+                        symbol: "test".to_string(),
+                        decimals: 0,
+                        total_supply: Uint128::from(100u128),
+                        mint: None,
+                    },
+                )
+                .with_smart_handler(TEST_LP_TOKEN_ADDR, |msg| {
+                    let res = match from_binary::<cw20::Cw20QueryMsg>(msg).unwrap() {
+                        cw20::Cw20QueryMsg::TokenInfo {} => cw20::TokenInfoResponse {
+                            name: "test".to_string(),
+                            symbol: "test".to_string(),
+                            decimals: 0,
+                            total_supply: Uint128::from(100u128),
+                        },
+                        _ => panic!("unexpected message"),
+                    };
+
+                    Ok(to_binary(&res).unwrap())
+                })
+                .build();
+
+            let target_asset = AssetInfo::native(TEST_ASSET_1);
+            let price_source = PriceSource::LiquidityToken {
+                pool_address: PoolAddress::contract(Addr::unchecked(TEST_POOL_ADDR)),
+                pool_assets: vec![target_asset.clone()],
+            };
+            let actual_res = price_source.lp_conversion(
+                deps.as_ref(),
+                &AssetInfo::cw20(Addr::unchecked(TEST_LP_TOKEN_ADDR)),
+                &Addr::unchecked(TEST_POOL_ADDR),
+                &[target_asset.clone()],
+            )?;
+
+            assert_that!(actual_res).has_length(1);
+            assert_that!(actual_res[0]).is_equal_to(AssetConversion {
+                into: target_asset,
+                ratio: Decimal::zero(),
+            });
+
+            Ok(())
+        }
+    }
 }

--- a/packages/abstract-testing/src/lib.rs
+++ b/packages/abstract-testing/src/lib.rs
@@ -35,7 +35,14 @@ pub mod addresses {
 
     pub const TEST_MODULE_RESPONSE: &str = "test_module_response";
 
+    pub const TEST_CHAIN: &str = "chain";
     pub const TEST_DEX: &str = "test_dex";
+    pub const TEST_ASSET_1: &str = "chain>asset1";
+    pub const TEST_ASSET_2: &str = "chain>asset2";
+    pub const TEST_LP_TOKEN_NAME: &str = "test_dex/chain>asset1,chain>asset2";
+    pub const TEST_LP_TOKEN_ADDR: &str = "test_dex_asset1_asset2_lp_token";
+    pub const TEST_POOL_ADDR: &str = "test_pool_address";
+    pub const TEST_UNIQUE_ID: u64 = 69u64;
     pub const TTOKEN: &str = "test_token";
     pub const EUR_USD_PAIR: &str = "dex:eur_usd_pair";
     pub const EUR_USD_LP: &str = "dex/eur,usd";
@@ -60,6 +67,7 @@ pub mod prelude {
     pub use addresses::*;
     pub use mock_querier::{map_key, mock_querier, raw_map_key, wrap_querier, MockQuerierBuilder};
 
+    pub use super::MockAnsHost;
     pub use super::MockDeps;
 
     pub use cosmwasm_std::{

--- a/packages/abstract-testing/src/mock_querier.rs
+++ b/packages/abstract-testing/src/mock_querier.rs
@@ -125,7 +125,7 @@ impl MockQuerierBuilder {
     ///        _ => panic!("unexpected message"),
     ///    };
     ///
-    ///   Ok(to_binary(&msg).unwrap())
+    ///   Ok(to_binary(&res).unwrap())
     /// }).build();
     /// ```
     pub fn with_smart_handler<SH: 'static>(mut self, contract: &str, handler: SH) -> Self


### PR DESCRIPTION
This PR adds tests for the following:
- `ibc_client` conversion methods 
- `ibc_host` conversion methods
- `AssetEntry::src_chain` and `asset_name`
- `PriceSource` check 
