### PR TITLE
Refactor api to adapter

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -12,9 +12,9 @@
 "sdk":
   # Match all of sdk folders
   - packages/abstract-sdk/**/*
-"api_base":
-  # Match all of api base folders
-  - packages/abstract-api/**/*
+"adapter_base":
+  # Match all of adapter base folders
+  - packages/abstract-adapter/**/*
 "app_base":
   # Match all of app base folders
   - packages/abstract-app/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fixed wasming with `write_api` error in the `abstract-api` and `abstract-app`
+- Fixed wasming with `write_api` error in the `abstract-adapter` and `abstract-app`
 
 ## [0.5.0] - 2022-01-08
 
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Abstract SDK
 
-- Better querying of app and api directly vs message construction
+- Better querying of app and adapter directly vs message construction
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ tokio = { version = "1.4", features = ["full"] }
 ## crates in order of publishing ## see docs/Publishing.md
 
 abstract-ibc-host = { path = "packages/abstract-ibc-host" }
-abstract-api = { path = "packages/abstract-api" }
+abstract-adapter = { path = "packages/abstract-adapter" }
 abstract-app = { path = "packages/abstract-app" }
 
 # Keep these as path, creates cirular dependency otherwise

--- a/contracts/account/manager/Cargo.toml
+++ b/contracts/account/manager/Cargo.toml
@@ -50,7 +50,7 @@ module-factory = { workspace = true }
 rstest = { workspace = true }
 speculoos = { workspace = true }
 abstract-sdk = { workspace = true, features = ["test-utils"] }
-abstract-api = { workspace = true, features = ["test-utils"] }
+abstract-adapter = { workspace = true, features = ["test-utils"] }
 abstract-app = { workspace = true, features = ["test-utils"] }
 abstract-testing = { workspace = true }
 abstract-macros = { workspace = true }

--- a/contracts/account/manager/VERSIONING.md
+++ b/contracts/account/manager/VERSIONING.md
@@ -2,13 +2,13 @@
 
 A document detailing the Abstract module versioning.
 
-Instead of storing dependencies we store dependents for each module. So if a module A depends on B and C, then B and C will have A as a dependent.  
+Instead of storing dependencies we store dependents for each module. So if a module A depends on B and C, then B and C will have A as a dependent.
 
 `DEPENDANTS: Map<ModuleId, Vec<ModuleId>>`
 
 ## Module version dependencies
 
-Every module (App/Api) has a set of dependencies it can declare. The dependencies ensure a couple things:
+Every module (App/Adapter) has a set of dependencies it can declare. The dependencies ensure a couple things:
 
 - A module can only be installed when it's dependencies are installed.
 - A module can not be un-installed as long as some other module depends on it. (entry for the module in the dependants map is not empty)
@@ -29,15 +29,15 @@ Version requirements are stored in the module itself and can be queried.
 ### Migration
 
 1. Retrieve new version number of module. (if not provided)
-2. Load dependents of the to-be-migrated module and assert new version passes dependent requirements.  
+2. Load dependents of the to-be-migrated module and assert new version passes dependent requirements.
     - Exclude any modules that are being migrated before. This ensures that the migration is not blocked by a module that is being migrated.
-3. Migrate all the modules that have applied for a migration.  
+3. Migrate all the modules that have applied for a migration.
 
 Then for each module that was migrated:
 
 1. Remove self as a dependent when it no longer applies. I.e. the module depended on a module A but no longer does after the migration.
 2. Add self as a dependent when it applies. I.e. the module did not depended on a module B but does after the migration.
-now what could happen is that the new version of the module 
+now what could happen is that the new version of the module
 2. Update dependency version.
 3. Add dependencies (there might be a new requirement)
 

--- a/contracts/account/manager/src/commands.rs
+++ b/contracts/account/manager/src/commands.rs
@@ -27,9 +27,9 @@ use abstract_sdk::{
     ModuleRegistryInterface,
 };
 
-use abstract_core::api::{
-    AuthorizedAddressesResponse, BaseExecuteMsg, BaseQueryMsg, ExecuteMsg as ApiExecMsg,
-    QueryMsg as ApiQuery,
+use abstract_core::adapter::{
+    AuthorizedAddressesResponse, BaseExecuteMsg, BaseQueryMsg, ExecuteMsg as AdapterExecMsg,
+    QueryMsg as AdapterQuery,
 };
 use abstract_sdk::cw_helpers::cosmwasm_std::AbstractAttributes;
 use cosmwasm_std::{
@@ -146,7 +146,7 @@ pub fn register_module(
             )?)
         }
         Module {
-            reference: ModuleReference::Api(_),
+            reference: ModuleReference::Adapter(_),
             info,
         } => {
             let id = info.id();
@@ -343,10 +343,13 @@ pub fn set_migrate_msgs_and_context(
     let requested_module = query_module(deps.as_ref(), module_info.clone(), Some(old_module_cw2))?;
 
     let migrate_msgs = match requested_module.reference {
-        // upgrading an api is done by moving the authorized addresses to the new contract address and updating the permissions on the proxy.
-        ModuleReference::Api(new_api_addr) => {
-            handle_api_migration(deps, requested_module.info, old_module_addr, new_api_addr)?
-        }
+        // upgrading an adapter is done by moving the authorized addresses to the new contract address and updating the permissions on the proxy.
+        ModuleReference::Adapter(new_adapter_addr) => handle_adapter_migration(
+            deps,
+            requested_module.info,
+            old_module_addr,
+            new_adapter_addr,
+        )?,
         ModuleReference::App(code_id) => handle_app_migration(
             deps,
             migrate_msg,
@@ -368,12 +371,12 @@ pub fn set_migrate_msgs_and_context(
     Ok(())
 }
 
-/// Handle API module migration and return the migration messages
-fn handle_api_migration(
+/// Handle Adapter module migration and return the migration messages
+fn handle_adapter_migration(
     mut deps: DepsMut,
     module_info: ModuleInfo,
-    old_api_addr: Addr,
-    new_api_addr: Addr,
+    old_adapter_addr: Addr,
+    new_adapter_addr: Addr,
 ) -> ManagerResult<Vec<CosmosMsg>> {
     let module_id = module_info.id();
     versioning::assert_migrate_requirements(
@@ -382,16 +385,16 @@ fn handle_api_migration(
         module_info.version.try_into()?,
     )?;
     let old_deps = versioning::load_module_dependencies(deps.as_ref(), &module_id)?;
-    // Update the address of the api internally
+    // Update the address of the adapter internally
     update_module_addresses(
         deps.branch(),
-        Some(vec![(module_id.clone(), new_api_addr.to_string())]),
+        Some(vec![(module_id.clone(), new_adapter_addr.to_string())]),
         None,
     )?;
 
     add_module_upgrade_to_context(deps.storage, &module_id, old_deps)?;
 
-    replace_api(deps, new_api_addr, old_api_addr)
+    replace_adapter(deps, new_adapter_addr, old_adapter_addr)
 }
 
 /// Handle app module migration and return the migration messages
@@ -446,21 +449,21 @@ fn build_module_migrate_msg(module_addr: Addr, new_code_id: u64, migrate_msg: Bi
     migration_msg
 }
 
-/// Replaces the current api with a different version
+/// Replaces the current adapter with a different version
 /// Also moves all the authorized address permissions to the new contract and removes them from the old
-pub fn replace_api(
+pub fn replace_adapter(
     deps: DepsMut,
-    new_api_addr: Addr,
-    old_api_addr: Addr,
+    new_adapter_addr: Addr,
+    old_adapter_addr: Addr,
 ) -> Result<Vec<CosmosMsg>, ManagerError> {
     let mut msgs = vec![];
-    // Makes sure we already have the api installed
+    // Makes sure we already have the adapter installed
     let proxy_addr = ACCOUNT_MODULES.load(deps.storage, PROXY)?;
     let AuthorizedAddressesResponse {
         addresses: authorized_addresses,
     } = deps.querier.query(&wasm_smart_query(
-        old_api_addr.to_string(),
-        &<ApiQuery<Empty>>::Base(BaseQueryMsg::AuthorizedAddresses {
+        old_adapter_addr.to_string(),
+        &<AdapterQuery<Empty>>::Base(BaseQueryMsg::AuthorizedAddresses {
             proxy_address: proxy_addr.to_string(),
         }),
     )?)?;
@@ -469,32 +472,35 @@ pub fn replace_api(
         .map(|addr| addr.into_string())
         .collect();
     // Remove authorized addresses from old
-    msgs.push(configure_api(
-        &old_api_addr,
+    msgs.push(configure_adapter(
+        &old_adapter_addr,
         BaseExecuteMsg::UpdateAuthorizedAddresses {
             to_add: vec![],
             to_remove: authorized_to_migrate.clone(),
         },
     )?);
-    // Remove api as authorized address on dependencies
-    msgs.push(configure_api(&old_api_addr, BaseExecuteMsg::Remove {})?);
+    // Remove adapter as authorized address on dependencies
+    msgs.push(configure_adapter(
+        &old_adapter_addr,
+        BaseExecuteMsg::Remove {},
+    )?);
     // Add authorized addresses to new
-    msgs.push(configure_api(
-        &new_api_addr,
+    msgs.push(configure_adapter(
+        &new_adapter_addr,
         BaseExecuteMsg::UpdateAuthorizedAddresses {
             to_add: authorized_to_migrate,
             to_remove: vec![],
         },
     )?);
-    // Remove api permissions from proxy
+    // Remove adapter permissions from proxy
     msgs.push(remove_module_from_proxy(
         proxy_addr.to_string(),
-        old_api_addr.into_string(),
+        old_adapter_addr.into_string(),
     )?);
-    // Add new api to proxy
+    // Add new adapter to proxy
     msgs.push(add_module_to_proxy(
         proxy_addr.into_string(),
-        new_api_addr.into_string(),
+        new_adapter_addr.into_string(),
     )?);
 
     Ok(msgs)
@@ -677,9 +683,12 @@ fn remove_module_from_proxy(
 }
 
 #[inline(always)]
-fn configure_api(api_address: impl Into<String>, message: BaseExecuteMsg) -> StdResult<CosmosMsg> {
-    let api_msg: ApiExecMsg<Empty> = message.into();
-    Ok(wasm_execute(api_address, &api_msg, vec![])?.into())
+fn configure_adapter(
+    adapter_address: impl Into<String>,
+    message: BaseExecuteMsg,
+) -> StdResult<CosmosMsg> {
+    let adapter_msg: AdapterExecMsg<Empty> = message.into();
+    Ok(wasm_execute(adapter_address, &adapter_msg, vec![])?.into())
 }
 
 pub fn update_account_status(

--- a/contracts/account/manager/src/versioning.rs
+++ b/contracts/account/manager/src/versioning.rs
@@ -229,19 +229,19 @@ mod test {
         fn remove() {
             let mut deps = mock_dependencies();
 
-            let dex_api = "dex";
+            let dex_adapter = "dex";
             let autocompounder = "autocompounder";
 
             // dex -> autocompounder
-            initialize_dependents(deps.as_mut(), dex_api, vec![autocompounder.to_string()]);
+            initialize_dependents(deps.as_mut(), dex_adapter, vec![autocompounder.to_string()]);
 
-            let actual_dex_dependents = DEPENDENTS.load(&deps.storage, dex_api).unwrap();
+            let actual_dex_dependents = DEPENDENTS.load(&deps.storage, dex_adapter).unwrap();
             assert_that(&actual_dex_dependents).has_length(1);
             assert_that(&actual_dex_dependents).contains(autocompounder.to_string());
 
             // the autocompounder depends on the dex
             let autocompounder_dependencies = vec![Dependency {
-                id: dex_api.to_string(),
+                id: dex_adapter.to_string(),
                 // no version requirements
                 version_req: vec![],
             }];
@@ -254,7 +254,7 @@ mod test {
 
             assert_that(&res).is_ok();
 
-            let remaining_dex_dependents = DEPENDENTS.load(&deps.storage, dex_api).unwrap();
+            let remaining_dex_dependents = DEPENDENTS.load(&deps.storage, dex_adapter).unwrap();
             assert_that(&remaining_dex_dependents).is_empty();
         }
     }

--- a/contracts/account/manager/tests/adapters.rs
+++ b/contracts/account/manager/tests/adapters.rs
@@ -1,44 +1,46 @@
 mod common;
 
-use abstract_api::mock::MockExecMsg;
+use abstract_adapter::mock::MockExecMsg;
 use abstract_boot::*;
 use abstract_core::manager::ManagerModuleInfo;
 use abstract_core::objects::module::{ModuleInfo, ModuleVersion};
-use abstract_core::{api::BaseQueryMsgFns, *};
+use abstract_core::{adapter::BaseQueryMsgFns, *};
 use abstract_testing::prelude::{OWNER, TEST_MODULE_ID, TEST_VERSION};
 use boot_core::{
     BootError, Mock, TxHandler, {instantiate_default_mock_env, CallAs, ContractInstance},
 };
 use boot_core::{BootExecute, Deploy};
-use common::{create_default_account, init_mock_api, AResult, TEST_COIN};
+use common::{create_default_account, init_mock_adapter, AResult, TEST_COIN};
 use cosmwasm_std::{Addr, Coin, Empty};
 // use cw_multi_test::StakingInfo;
 use speculoos::{assert_that, result::ResultAssertions, string::StrAssertions};
 
-fn install_api(manager: &Manager<Mock>, api: &str) -> AResult {
-    manager.install_module(api, &Empty {}).map_err(Into::into)
+fn install_adapter(manager: &Manager<Mock>, adapter_id: &str) -> AResult {
+    manager
+        .install_module(adapter_id, &Empty {})
+        .map_err(Into::into)
 }
 
-pub(crate) fn uninstall_module(manager: &Manager<Mock>, api: &str) -> AResult {
+pub(crate) fn uninstall_module(manager: &Manager<Mock>, module_id: &str) -> AResult {
     manager
-        .uninstall_module(api.to_string())
+        .uninstall_module(module_id.to_string())
         .map_err(Into::<BootError>::into)?;
     Ok(())
 }
 
 #[test]
-fn installing_one_api_should_succeed() -> AResult {
+fn installing_one_adapter_should_succeed() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let staking_api = init_mock_api(chain, &deployment, None)?;
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    let staking_adapter = init_mock_adapter(chain, &deployment, None)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
-    let modules = account.expect_modules(vec![staking_api.address()?.to_string()])?;
+    let modules = account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.address()?,
+        address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -47,28 +49,29 @@ fn installing_one_api_should_succeed() -> AResult {
     });
 
     // Configuration is correct
-    let api_config = staking_api.config()?;
-    assert_that!(api_config).is_equal_to(api::ApiConfigResponse {
+    let adapter_config = staking_adapter.config()?;
+    assert_that!(adapter_config).is_equal_to(adapter::AdapterConfigResponse {
         ans_host_address: deployment.ans_host.address()?,
         dependencies: vec![],
         version_control_address: deployment.version_control.address()?,
     });
 
     // no authorized addresses registered
-    let authorized = staking_api.authorized_addresses(account.proxy.addr_str()?)?;
-    assert_that!(authorized).is_equal_to(api::AuthorizedAddressesResponse { addresses: vec![] });
+    let authorized = staking_adapter.authorized_addresses(account.proxy.addr_str()?)?;
+    assert_that!(authorized)
+        .is_equal_to(adapter::AuthorizedAddressesResponse { addresses: vec![] });
 
     Ok(())
 }
 
 #[test]
-fn install_non_existent_apiname_should_fail() -> AResult {
+fn install_non_existent_adapterid_should_fail() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain, TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
 
-    let res = install_api(&account.manager, "lol:no_chance");
+    let res = install_adapter(&account.manager, "lol:no_chance");
 
     assert_that!(res).is_err();
     Ok(())
@@ -80,7 +83,7 @@ fn install_non_existent_version_should_fail() -> AResult {
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    init_mock_api(chain, &deployment, None)?;
+    init_mock_adapter(chain, &deployment, None)?;
 
     let res = account.manager.install_module_version(
         TEST_MODULE_ID,
@@ -95,21 +98,21 @@ fn install_non_existent_version_should_fail() -> AResult {
 }
 
 #[test]
-fn installation_of_duplicate_api_should_fail() -> AResult {
+fn installation_of_duplicate_adapter_should_fail() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let staking_api = init_mock_api(chain, &deployment, None)?;
+    let staking_adapter = init_mock_adapter(chain, &deployment, None)?;
 
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
-    let modules = account.expect_modules(vec![staking_api.address()?.to_string()])?;
+    let modules = account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
     // assert proxy module
-    // check staking api
+    // check staking adapter
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.address()?,
+        address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -118,31 +121,31 @@ fn installation_of_duplicate_api_should_fail() -> AResult {
     });
 
     // install again
-    let second_install_res = install_api(&account.manager, TEST_MODULE_ID);
+    let second_install_res = install_adapter(&account.manager, TEST_MODULE_ID);
     assert_that!(second_install_res)
         .is_err()
         .matches(|e| e.to_string().contains("test-module-id"));
 
-    account.expect_modules(vec![staking_api.address()?.to_string()])?;
+    account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
     Ok(())
 }
 
 #[test]
-fn reinstalling_api_should_be_allowed() -> AResult {
+fn reinstalling_adapter_should_be_allowed() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let staking_api = init_mock_api(chain, &deployment, None)?;
+    let staking_adapter = init_mock_adapter(chain, &deployment, None)?;
 
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
-    let modules = account.expect_modules(vec![staking_api.address()?.to_string()])?;
+    let modules = account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
-    // check staking api
+    // check staking adapter
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.address()?,
+        address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -157,29 +160,29 @@ fn reinstalling_api_should_be_allowed() -> AResult {
     account.expect_modules(vec![])?;
 
     // reinstall
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
-    account.expect_modules(vec![staking_api.address()?.to_string()])?;
+    account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
     Ok(())
 }
 
-/// Reinstalling the API should install the latest version
+/// Reinstalling the Adapter should install the latest version
 #[test]
 fn reinstalling_new_version_should_install_latest() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let staking_api = init_mock_api(chain.clone(), &deployment, Some("1.0.0".to_string()))?;
+    let staking_adapter = init_mock_adapter(chain.clone(), &deployment, Some("1.0.0".to_string()))?;
 
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
-    let modules = account.expect_modules(vec![staking_api.address()?.to_string()])?;
+    let modules = account.expect_modules(vec![staking_adapter.address()?.to_string()])?;
 
-    // check staking api
+    // check staking adapter
     assert_that(&modules[1]).is_equal_to(&ManagerModuleInfo {
-        address: staking_api.address()?,
+        address: staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -194,10 +197,11 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
 
     // Register the new version
     let new_version_num = "100.0.0";
-    let old_api_addr = staking_api.address()?;
+    let old_adapter_addr = staking_adapter.address()?;
 
-    // We init the staking api with a new version to ensure that we get a new address
-    let new_staking_api = init_mock_api(chain, &deployment, Some(new_version_num.to_string()))?;
+    // We init the staking adapter with a new version to ensure that we get a new address
+    let new_staking_adapter =
+        init_mock_adapter(chain, &deployment, Some(new_version_num.to_string()))?;
 
     // check that the latest staking version is the new one
     let latest_staking = deployment
@@ -207,13 +211,13 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
         .is_equal_to(ModuleVersion::Version(new_version_num.to_string()));
 
     // reinstall
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
-    let modules = account.expect_modules(vec![new_staking_api.address()?.to_string()])?;
+    let modules = account.expect_modules(vec![new_staking_adapter.address()?.to_string()])?;
 
     assert_that!(modules[1]).is_equal_to(&ManagerModuleInfo {
-        // the address stored for BootMockApi was updated when we instantiated the new version, so this is the new address
-        address: new_staking_api.address()?,
+        // the address stored for BootMockAdapter was updated when we instantiated the new version, so this is the new address
+        address: new_staking_adapter.address()?,
         id: TEST_MODULE_ID.to_string(),
         version: cw2::ContractVersion {
             contract: TEST_MODULE_ID.into(),
@@ -222,10 +226,10 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
             version: TEST_VERSION.to_string(),
         },
     });
-    // assert that the new staking api has a different address
-    assert_ne!(old_api_addr, new_staking_api.address()?);
+    // assert that the new staking adapter has a different address
+    assert_ne!(old_adapter_addr, new_staking_adapter.address()?);
 
-    assert_that!(modules[1].address).is_equal_to(new_staking_api.as_instance().address()?);
+    assert_that!(modules[1].address).is_equal_to(new_staking_adapter.as_instance().address()?);
 
     Ok(())
 }
@@ -239,10 +243,10 @@ fn unauthorized_exec() -> AResult {
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let staking_api = init_mock_api(chain, &deployment, None)?;
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    let staking_adapter = init_mock_adapter(chain, &deployment, None)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
     // non-authorized address cannot execute
-    let res = staking_api
+    let res = staking_adapter
         .call_as(&unauthorized)
         .execute(&MockExecMsg.into(), None)
         .unwrap_err();
@@ -250,7 +254,9 @@ fn unauthorized_exec() -> AResult {
         "Sender: unauthorized of request to tester:test-module-id is not a Manager or Authorized Address",
     );
     // neither can the ROOT directly
-    let res = staking_api.execute(&MockExecMsg.into(), None).unwrap_err();
+    let res = staking_adapter
+        .execute(&MockExecMsg.into(), None)
+        .unwrap_err();
     assert_that!(&res.root().to_string()).contains(
         "Sender: owner of request to tester:test-module-id is not a Manager or Authorized Address",
     );
@@ -258,14 +264,15 @@ fn unauthorized_exec() -> AResult {
 }
 
 #[test]
-fn manager_api_exec_staking_delegation() -> AResult {
+fn manager_adapter_exec_staking_delegation() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let _staking_api_one = init_mock_api(chain.clone(), &deployment, Some("1.2.3".to_string()))?;
+    let _staking_adapter_one =
+        init_mock_adapter(chain.clone(), &deployment, Some("1.2.3".to_string()))?;
 
-    install_api(&account.manager, TEST_MODULE_ID)?;
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
 
     chain.set_balance(
         &account.proxy.address()?,
@@ -274,7 +281,7 @@ fn manager_api_exec_staking_delegation() -> AResult {
 
     account.manager.execute_on_module(
         TEST_MODULE_ID,
-        Into::<abstract_core::api::ExecuteMsg<MockExecMsg>>::into(MockExecMsg),
+        Into::<abstract_core::adapter::ExecuteMsg<MockExecMsg>>::into(MockExecMsg),
     )?;
 
     Ok(())
@@ -286,13 +293,14 @@ fn installing_specific_version_should_install_expected() -> AResult {
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let deployment = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse().unwrap())?;
     let account = create_default_account(&deployment.account_factory)?;
-    let _staking_api_one = init_mock_api(chain.clone(), &deployment, Some("1.2.3".to_string()))?;
+    let _staking_adapter_one =
+        init_mock_adapter(chain.clone(), &deployment, Some("1.2.3".to_string()))?;
     let expected_version = "2.3.4".to_string();
-    let expected_staking_api =
-        init_mock_api(chain.clone(), &deployment, Some(expected_version.clone()))?;
-    let expected_staking_api_addr = expected_staking_api.address()?.to_string();
+    let expected_staking_adapter =
+        init_mock_adapter(chain.clone(), &deployment, Some(expected_version.clone()))?;
+    let expected_staking_adapter_addr = expected_staking_adapter.address()?.to_string();
 
-    let _staking_api_three = init_mock_api(chain, &deployment, Some("3.4.5".to_string()))?;
+    let _staking_adapter_three = init_mock_adapter(chain, &deployment, Some("3.4.5".to_string()))?;
 
     // install specific version
     account.manager.install_module_version(
@@ -301,7 +309,7 @@ fn installing_specific_version_should_install_expected() -> AResult {
         &Empty {},
     )?;
 
-    let modules = account.expect_modules(vec![expected_staking_api_addr])?;
+    let modules = account.expect_modules(vec![expected_staking_adapter_addr])?;
     let installed_module: ManagerModuleInfo = modules[1].clone();
     assert_that!(installed_module.id).is_equal_to(TEST_MODULE_ID.to_string());
 

--- a/contracts/account/manager/tests/common/mock_modules.rs
+++ b/contracts/account/manager/tests/common/mock_modules.rs
@@ -1,43 +1,44 @@
 #![allow(dead_code)]
 
-use abstract_api::gen_api_mock;
-use abstract_api::mock::MockInitMsg;
-use abstract_api::{mock::MockError as ApiMockError, ApiContract};
+use abstract_adapter::gen_adapter_mock;
+use abstract_adapter::mock::MockInitMsg;
+use abstract_adapter::{mock::MockError as AdapterMockError, AdapterContract};
 use abstract_app::gen_app_mock;
 use abstract_app::mock::MockError as AppMockError;
 use abstract_app::AppContract;
-use abstract_boot::{ApiDeployer, AppDeployer};
+use abstract_boot::{AdapterDeployer, AppDeployer};
 use abstract_core::objects::dependency::StaticDependency;
 // use boot_core::{ContractWrapper};
 use boot_core::{Empty, Mock};
 
-pub type MockApiContract = ApiContract<ApiMockError, Empty, Empty, Empty, Empty, Empty>;
+pub type MockAdapterContract = AdapterContract<AdapterMockError, Empty, Empty, Empty, Empty, Empty>;
 pub type MockAppContract = AppContract<AppMockError, Empty, Empty, Empty, Empty, Empty, Empty>;
-pub use self::api_1::*;
-pub use self::api_2::*;
+
+pub use self::adapter_1::*;
+pub use self::adapter_2::*;
 pub use self::app_1::*;
 
 pub const V1: &str = "1.0.0";
 pub const V2: &str = "2.0.0";
 
-/// deploys different version apis and app for migration testing
+/// deploys different version adapters and app for migration testing
 pub fn deploy_modules(mock: &Mock) {
-    self::BootMockApi1V1::new(mock.clone())
+    self::BootMockAdapter1V1::new(mock.clone())
         .deploy(V1.parse().unwrap(), MockInitMsg)
         .unwrap();
 
     // do same for version 2
-    self::BootMockApi1V2::new(mock.clone())
+    self::BootMockAdapter1V2::new(mock.clone())
         .deploy(V2.parse().unwrap(), MockInitMsg)
         .unwrap();
 
-    // and now for api 2
-    self::BootMockApi2V1::new(mock.clone())
+    // and now for adapter 2
+    self::BootMockAdapter2V1::new(mock.clone())
         .deploy(V1.parse().unwrap(), MockInitMsg)
         .unwrap();
 
     // do same for version 2
-    self::BootMockApi2V2::new(mock.clone())
+    self::BootMockAdapter2V2::new(mock.clone())
         .deploy(V2.parse().unwrap(), MockInitMsg)
         .unwrap();
 
@@ -52,50 +53,51 @@ pub fn deploy_modules(mock: &Mock) {
         .unwrap();
 }
 
-pub mod api_1 {
+pub mod adapter_1 {
     use super::*;
 
-    pub const MOCK_API_ID: &str = "tester:mock-api1";
+    pub const MOCK_ADAPTER_ID: &str = "tester:mock-adapter1";
+
     pub use self::v1::*;
     pub use self::v2::*;
 
     pub mod v1 {
-
         use super::*;
-        gen_api_mock!(BootMockApi1V1, MOCK_API_ID, "1.0.0", &[]);
+        gen_adapter_mock!(BootMockAdapter1V1, MOCK_ADAPTER_ID, "1.0.0", &[]);
     }
 
     pub mod v2 {
         use super::*;
-        gen_api_mock!(BootMockApi1V2, MOCK_API_ID, "2.0.0", &[]);
+        gen_adapter_mock!(BootMockAdapter1V2, MOCK_ADAPTER_ID, "2.0.0", &[]);
     }
 }
 
-pub mod api_2 {
+pub mod adapter_2 {
     use super::*;
 
-    pub const MOCK_API_ID: &str = "tester:mock-api2";
+    pub const MOCK_ADAPTER_ID: &str = "tester:mock-adapter2";
+
     pub use self::v0_1_0::*;
     pub use self::v1::*;
     pub use self::v2_0_0::*;
 
     pub mod v1 {
         use super::*;
-        gen_api_mock!(BootMockApi2V1, MOCK_API_ID, "1.0.0", &[]);
+        gen_adapter_mock!(BootMockAdapter2V1, MOCK_ADAPTER_ID, "1.0.0", &[]);
     }
 
     pub mod v2_0_0 {
         use super::*;
-        gen_api_mock!(BootMockApi2V2, MOCK_API_ID, "2.0.0", &[]);
+        gen_adapter_mock!(BootMockAdapter2V2, MOCK_ADAPTER_ID, "2.0.0", &[]);
     }
 
     pub mod v0_1_0 {
         use super::*;
-        gen_api_mock!(BootMockApi2V0_1_0, MOCK_API_ID, "0.1.0", &[]);
+        gen_adapter_mock!(BootMockAdapter2V0_1_0, MOCK_ADAPTER_ID, "0.1.0", &[]);
     }
 }
 
-// app 1 depends on api 1 and api 2
+// app 1 depends on adapter 1 and adapter 2
 pub mod app_1 {
     use super::*;
     pub use v1::*;
@@ -108,8 +110,8 @@ pub mod app_1 {
             MOCK_APP_ID,
             "1.0.0",
             &[
-                StaticDependency::new(api_1::MOCK_API_ID, &[V1]),
-                StaticDependency::new(api_2::MOCK_API_ID, &[V1]),
+                StaticDependency::new(adapter_1::MOCK_ADAPTER_ID, &[V1]),
+                StaticDependency::new(adapter_2::MOCK_ADAPTER_ID, &[V1]),
             ]
         );
     }
@@ -121,8 +123,8 @@ pub mod app_1 {
             MOCK_APP_ID,
             "2.0.0",
             &[
-                StaticDependency::new(api_1::MOCK_API_ID, &[V2]),
-                StaticDependency::new(api_2::MOCK_API_ID, &[V2]),
+                StaticDependency::new(adapter_1::MOCK_ADAPTER_ID, &[V2]),
+                StaticDependency::new(adapter_2::MOCK_ADAPTER_ID, &[V2]),
             ]
         );
     }

--- a/contracts/account/manager/tests/common/mod.rs
+++ b/contracts/account/manager/tests/common/mod.rs
@@ -5,11 +5,11 @@ pub const OWNER: &str = "owner";
 pub const TEST_COIN: &str = "ucoin";
 
 use ::abstract_manager::contract::CONTRACT_VERSION;
-use abstract_api::mock::{BootMockApi, MockInitMsg};
+use abstract_adapter::mock::{BootMockAdapter, MockInitMsg};
 use abstract_boot::{
     Abstract, AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VCExecFns, VersionControl,
 };
-use abstract_boot::{AbstractAccount, ApiDeployer};
+use abstract_boot::{AbstractAccount, AdapterDeployer};
 use abstract_core::version_control::AccountBase;
 use abstract_core::{objects::gov_type::GovernanceDetails, PROXY};
 use abstract_core::{ACCOUNT_FACTORY, ANS_HOST, MANAGER, MODULE_FACTORY, VERSION_CONTROL};
@@ -31,18 +31,18 @@ pub(crate) fn create_default_account(
 
 use abstract_testing::addresses::{TEST_ACCOUNT_ID, TEST_MODULE_ID};
 
-pub(crate) fn init_mock_api(
+pub(crate) fn init_mock_adapter(
     chain: Mock,
     deployment: &Abstract<Mock>,
     version: Option<String>,
-) -> anyhow::Result<BootMockApi<Mock>> {
+) -> anyhow::Result<BootMockAdapter<Mock>> {
     deployment
         .version_control
         .claim_namespaces(TEST_ACCOUNT_ID, vec!["tester".to_string()]);
-    let mut staking_api = BootMockApi::new(TEST_MODULE_ID, chain);
+    let mut staking_adapter = BootMockAdapter::new(TEST_MODULE_ID, chain);
     let version: Version = version
         .unwrap_or_else(|| CONTRACT_VERSION.to_string())
         .parse()?;
-    staking_api.deploy(version, MockInitMsg)?;
-    Ok(staking_api)
+    staking_adapter.deploy(version, MockInitMsg)?;
+    Ok(staking_adapter)
 }

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -49,30 +49,30 @@ fn install_app_successful() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    // dependency for mock_api1 not met
+    // dependency for mock_adapter1 not met
     let res = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V1);
     assert_that!(&res).is_err();
     assert_that!(res.unwrap_err().root_cause().to_string()).contains(
-        "module tester:mock-api1 is a dependency of tester:mock-app1 and is not installed.",
+        "module tester:mock-adapter1 is a dependency of tester:mock-app1 and is not installed.",
     );
 
-    // install api 1
-    let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
+    // install adapter 1
+    let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
 
     // second dependency still not met
     let res = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V1);
     assert_that!(&res).is_err();
     assert_that!(res.unwrap_err().root_cause().to_string()).contains(
-        "module tester:mock-api2 is a dependency of tester:mock-app1 and is not installed.",
+        "module tester:mock-adapter2 is a dependency of tester:mock-app1 and is not installed.",
     );
 
-    // install api 2
-    let api2 = install_module_version(manager, &abstr, api_2::MOCK_API_ID, V1)?;
+    // install adapter 2
+    let adapter2 = install_module_version(manager, &abstr, adapter_2::MOCK_ADAPTER_ID, V1)?;
 
     // successfully install app 1
     let app1 = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V1)?;
 
-    account.expect_modules(vec![api1, api2, app1])?;
+    account.expect_modules(vec![adapter1, adapter2, app1])?;
     Ok(())
 }
 
@@ -88,18 +88,18 @@ fn install_app_versions_not_met() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    // install api 2
-    let _api2 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
+    // install adapter 2
+    let _adapter2 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
 
     // successfully install app 1
-    let _app1 = install_module_version(manager, &abstr, api_2::MOCK_API_ID, V1)?;
+    let _app1 = install_module_version(manager, &abstr, adapter_2::MOCK_ADAPTER_ID, V1)?;
 
     // attempt to install app with version 2
 
     let res = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V2);
     assert_that!(&res).is_err();
     assert_that!(res.unwrap_err().root_cause().to_string())
-        .contains("Module tester:mock-api1 with version 1.0.0 does not fit requirement ^2.0.0");
+        .contains("Module tester:mock-adapter1 with version 1.0.0 does not fit requirement ^2.0.0");
     Ok(())
 }
 
@@ -115,15 +115,15 @@ fn upgrade_app() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    // install api 1
-    let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
+    // install adapter 1
+    let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
 
-    // install api 2
-    let api2 = install_module_version(manager, &abstr, api_2::MOCK_API_ID, V1)?;
+    // install adapter 2
+    let adapter2 = install_module_version(manager, &abstr, adapter_2::MOCK_ADAPTER_ID, V1)?;
 
     // successfully install app 1
     let app1 = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V1)?;
-    account.expect_modules(vec![api1, api2, app1])?;
+    account.expect_modules(vec![adapter1, adapter2, app1])?;
 
     // attempt upgrade app 1 to version 2
     let res = manager.upgrade_module(
@@ -133,10 +133,10 @@ fn upgrade_app() -> AResult {
             module: MockMigrateMsg,
         },
     );
-    // fails because api 1 is not version 2
+    // fails because adapter 1 is not version 2
     assert_that!(res.unwrap_err().root().to_string()).contains(
         ManagerError::VersionRequirementNotMet {
-            module_id: api_1::MOCK_API_ID.into(),
+            module_id: adapter_1::MOCK_ADAPTER_ID.into(),
             version: V1.into(),
             comp: "^2.0.0".into(),
             post_migration: true,
@@ -144,18 +144,18 @@ fn upgrade_app() -> AResult {
         .to_string(),
     );
 
-    // upgrade api 1 to version 2
+    // upgrade adapter 1 to version 2
     let res = manager.upgrade_module(
-        api_1::MOCK_API_ID,
+        adapter_1::MOCK_ADAPTER_ID,
         &app::MigrateMsg {
             base: app::BaseMigrateMsg {},
             module: Empty {},
         },
     );
-    // fails because app v1 is not version 2 and depends on api 1 being version 1.
+    // fails because app v1 is not version 2 and depends on adapter 1 being version 1.
     assert_that!(res.unwrap_err().root().to_string()).contains(
         ManagerError::VersionRequirementNotMet {
-            module_id: api_1::MOCK_API_ID.into(),
+            module_id: adapter_1::MOCK_ADAPTER_ID.into(),
             version: V2.into(),
             comp: "^1.0.0".into(),
             post_migration: false,
@@ -175,11 +175,17 @@ fn upgrade_app() -> AResult {
                 module: MockMigrateMsg,
             })?),
         ),
-        (ModuleInfo::from_id_latest(api_1::MOCK_API_ID)?, None),
-        (ModuleInfo::from_id_latest(api_2::MOCK_API_ID)?, None),
+        (
+            ModuleInfo::from_id_latest(adapter_1::MOCK_ADAPTER_ID)?,
+            None,
+        ),
+        (
+            ModuleInfo::from_id_latest(adapter_2::MOCK_ADAPTER_ID)?,
+            None,
+        ),
     ]);
 
-    // fails because app v1 is depends on api 1 being version 1.
+    // fails because app v1 is depends on adapter 1 being version 1.
     assert_that!(res.unwrap_err().root().to_string()).contains(
         ManagerError::Abstract(AbstractError::CannotDowngradeContract {
             contract: app_1::MOCK_APP_ID.into(),
@@ -198,10 +204,10 @@ fn upgrade_app() -> AResult {
         })?),
     )]);
 
-    // fails because app v1 is depends on api 1 being version 2.
+    // fails because app v1 is depends on adapter 1 being version 2.
     assert_that!(res.unwrap_err().root().to_string()).contains(
         ManagerError::VersionRequirementNotMet {
-            module_id: api_1::MOCK_API_ID.into(),
+            module_id: adapter_1::MOCK_ADAPTER_ID.into(),
             version: V1.into(),
             comp: "^2.0.0".into(),
             post_migration: true,
@@ -219,19 +225,25 @@ fn upgrade_app() -> AResult {
             })?),
         ),
         (
-            ModuleInfo::from_id(api_1::MOCK_API_ID, ModuleVersion::Version(V1.to_string()))?,
+            ModuleInfo::from_id(
+                adapter_1::MOCK_ADAPTER_ID,
+                ModuleVersion::Version(V1.to_string()),
+            )?,
             None,
         ),
         (
-            ModuleInfo::from_id(api_2::MOCK_API_ID, ModuleVersion::Version(V1.to_string()))?,
+            ModuleInfo::from_id(
+                adapter_2::MOCK_ADAPTER_ID,
+                ModuleVersion::Version(V1.to_string()),
+            )?,
             None,
         ),
     ]);
 
-    // fails because app v1 is depends on api 1 being version 2.
+    // fails because app v1 is depends on adapter 1 being version 2.
     assert_that!(res.unwrap_err().root().to_string()).contains(
         ManagerError::VersionRequirementNotMet {
-            module_id: api_1::MOCK_API_ID.into(),
+            module_id: adapter_1::MOCK_ADAPTER_ID.into(),
             version: V1.into(),
             comp: "^2.0.0".into(),
             post_migration: true,
@@ -248,8 +260,14 @@ fn upgrade_app() -> AResult {
                 module: MockMigrateMsg,
             })?),
         ),
-        (ModuleInfo::from_id_latest(api_1::MOCK_API_ID)?, None),
-        (ModuleInfo::from_id_latest(api_2::MOCK_API_ID)?, None),
+        (
+            ModuleInfo::from_id_latest(adapter_1::MOCK_ADAPTER_ID)?,
+            None,
+        ),
+        (
+            ModuleInfo::from_id_latest(adapter_2::MOCK_ADAPTER_ID)?,
+            None,
+        ),
     ])?;
 
     Ok(())
@@ -267,31 +285,31 @@ fn uninstall_modules() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
-    let api2 = install_module_version(manager, &abstr, api_2::MOCK_API_ID, V1)?;
+    let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
+    let adapter2 = install_module_version(manager, &abstr, adapter_2::MOCK_ADAPTER_ID, V1)?;
     let app1 = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V1)?;
-    account.expect_modules(vec![api1, api2, app1])?;
+    account.expect_modules(vec![adapter1, adapter2, app1])?;
 
-    let res = manager.uninstall_module(api_1::MOCK_API_ID.to_string());
-    // fails because app is depends on api 1
+    let res = manager.uninstall_module(adapter_1::MOCK_ADAPTER_ID.to_string());
+    // fails because app is depends on adapter 1
     assert_that!(res.unwrap_err().root().to_string())
         .contains(ManagerError::ModuleHasDependents(vec![app_1::MOCK_APP_ID.into()]).to_string());
-    // same for api 2
-    let res = manager.uninstall_module(api_2::MOCK_API_ID.to_string());
+    // same for adapter 2
+    let res = manager.uninstall_module(adapter_2::MOCK_ADAPTER_ID.to_string());
     assert_that!(res.unwrap_err().root().to_string())
         .contains(ManagerError::ModuleHasDependents(vec![app_1::MOCK_APP_ID.into()]).to_string());
 
     // we can only uninstall if the app is uninstalled first
     manager.uninstall_module(app_1::MOCK_APP_ID.to_string())?;
-    // now we can uninstall api 1
-    manager.uninstall_module(api_1::MOCK_API_ID.to_string())?;
-    // and api 2
-    manager.uninstall_module(api_2::MOCK_API_ID.to_string())?;
+    // now we can uninstall adapter 1
+    manager.uninstall_module(adapter_1::MOCK_ADAPTER_ID.to_string())?;
+    // and adapter 2
+    manager.uninstall_module(adapter_2::MOCK_ADAPTER_ID.to_string())?;
     Ok(())
 }
 
 #[test]
-fn update_api_with_authorized_addrs() -> AResult {
+fn update_adapter_with_authorized_addrs() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let (_state, chain) = instantiate_default_mock_env(&sender)?;
     let abstr = Abstract::deploy_on(chain.clone(), TEST_VERSION.parse()?)?;
@@ -302,39 +320,39 @@ fn update_api_with_authorized_addrs() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    // install api 1
-    let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
-    account.expect_modules(vec![api1.clone()])?;
+    // install adapter 1
+    let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
+    account.expect_modules(vec![adapter1.clone()])?;
 
-    // register an authorized address on API1
+    // register an authorized address on Adapter 1
     let authorizee = "authorizee";
-    manager.update_api_authorized_addresses(
-        api_1::MOCK_API_ID,
+    manager.update_adapter_authorized_addresses(
+        adapter_1::MOCK_ADAPTER_ID,
         vec![authorizee.to_string()],
         vec![],
     )?;
 
-    // upgrade api 1 to version 2
+    // upgrade adapter 1 to version 2
     manager.upgrade_module(
-        api_1::MOCK_API_ID,
+        adapter_1::MOCK_ADAPTER_ID,
         &app::MigrateMsg {
             base: app::BaseMigrateMsg {},
             module: Empty {},
         },
     )?;
     use abstract_core::manager::QueryMsgFns as _;
-    let api_v2 = manager.module_addresses(vec![api_1::MOCK_API_ID.into()])?;
+    let adapter_v2 = manager.module_addresses(vec![adapter_1::MOCK_ADAPTER_ID.into()])?;
     // assert that the address actually changed
-    assert_that!(api_v2.modules[0].1).is_not_equal_to(Addr::unchecked(api1.clone()));
+    assert_that!(adapter_v2.modules[0].1).is_not_equal_to(Addr::unchecked(adapter1.clone()));
 
-    let api = api_1::BootMockApi1V2::new(chain);
-    use abstract_core::api::BaseQueryMsgFns as _;
-    let authorized = api.authorized_addresses(proxy.addr_str()?)?;
+    let adapter = adapter_1::BootMockAdapter1V2::new(chain);
+    use abstract_core::adapter::BaseQueryMsgFns as _;
+    let authorized = adapter.authorized_addresses(proxy.addr_str()?)?;
     assert_that!(authorized.addresses).contains(Addr::unchecked(authorizee));
 
-    // assert that authorized address was removed from old API
-    api.set_address(&Addr::unchecked(api1));
-    let authorized = api.authorized_addresses(proxy.addr_str()?)?;
+    // assert that authorized address was removed from old Adapter
+    adapter.set_address(&Addr::unchecked(adapter1));
+    let authorized = adapter.authorized_addresses(proxy.addr_str()?)?;
     assert_that!(authorized.addresses).is_empty();
     Ok(())
 }
@@ -352,15 +370,15 @@ fn upgrade_manager_last() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    // install api 1
-    let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
+    // install adapter 1
+    let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
 
-    // install api 2
-    let api2 = install_module_version(manager, &abstr, api_2::MOCK_API_ID, V1)?;
+    // install adapter 2
+    let adapter2 = install_module_version(manager, &abstr, adapter_2::MOCK_ADAPTER_ID, V1)?;
 
     // successfully install app 1
     let app1 = install_module_version(manager, &abstr, app_1::MOCK_APP_ID, V1)?;
-    account.expect_modules(vec![api1, api2, app1])?;
+    account.expect_modules(vec![adapter1, adapter2, app1])?;
 
     // Upgrade all modules, including the manager module, but ensure the manager is upgraded last
     let res = manager.upgrade(vec![
@@ -375,8 +393,8 @@ fn upgrade_manager_last() -> AResult {
             ModuleInfo::from_id_latest("abstract:manager")?,
             Some(to_binary(&manager::MigrateMsg {})?),
         ),
-        (ModuleInfo::from_id_latest(api_1::MOCK_API_ID)?, None),
-        (ModuleInfo::from_id_latest(api_2::MOCK_API_ID)?, None),
+        (ModuleInfo::from_id_latest(adapter_1::MOCK_ADAPTER_ID)?, None),
+        (ModuleInfo::from_id_latest(adapter_2::MOCK_ADAPTER_ID)?, None),
     ])?;
 
     // get the events
@@ -414,22 +432,28 @@ fn no_duplicate_migrations() -> AResult {
         .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
-    // Install api 1
-    let api1 = install_module_version(manager, &abstr, api_1::MOCK_API_ID, V1)?;
+    // Install adapter 1
+    let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
 
-    account.expect_modules(vec![api1])?;
+    account.expect_modules(vec![adapter1])?;
 
     // Upgrade all modules, including the manager module
     let res = manager.upgrade(vec![
-        (ModuleInfo::from_id_latest(api_1::MOCK_API_ID)?, None),
-        (ModuleInfo::from_id_latest(api_1::MOCK_API_ID)?, None),
+        (
+            ModuleInfo::from_id_latest(adapter_1::MOCK_ADAPTER_ID)?,
+            None,
+        ),
+        (
+            ModuleInfo::from_id_latest(adapter_1::MOCK_ADAPTER_ID)?,
+            None,
+        ),
     ]);
 
     assert_that!(res).is_err();
 
     assert_that!(res.unwrap_err().root().to_string()).is_equal_to(
         ManagerError::DuplicateModuleMigration {
-            module_id: api_1::MOCK_API_ID.to_string(),
+            module_id: adapter_1::MOCK_ADAPTER_ID.to_string(),
         }
         .to_string(),
     );
@@ -438,6 +462,6 @@ fn no_duplicate_migrations() -> AResult {
 }
 
 // TODO:
-// - api-api dependencies
-// - app-api dependencies
+// - adapter-adapter dependencies
+// - app-adapter dependencies
 // - app-app dependencies

--- a/contracts/ibc-hosts/osmosis/examples/schema.rs
+++ b/contracts/ibc-hosts/osmosis/examples/schema.rs
@@ -1,5 +1,5 @@
 use abstract_sdk::core::{
-    api::{ApiConfigResponse, AuthorizedAddressesResponse},
+    adapter::{AdapterConfigResponse, AuthorizedAddressesResponse},
     dex::SimulateSwapResponse,
 };
 use cosmwasm_schema::{export_schema_with_title, remove_schemas, schema_for};
@@ -15,15 +15,17 @@ fn main() {
 
     OsmoHost::export_schema(&out_dir);
 
-    export_schema_with_title(&schema_for!(SimulateSwapResponse), &out_dir, "ApiResponse");
-
     // export_schema_with_title(&schema_for!(ExecuteMsg<DexRequestMsg>), &out_dir, "ExecuteMsg");
     export_schema_with_title(
         &schema_for!(AuthorizedAddressesResponse),
         &out_dir,
         "AuthorizedAddressesResponse",
     );
-    export_schema_with_title(&schema_for!(ApiConfigResponse), &out_dir, "ConfigResponse");
+    export_schema_with_title(
+        &schema_for!(AdapterConfigResponse),
+        &out_dir,
+        "ConfigResponse",
+    );
 
-    // export_schema_with_title(&schema_for!(ApiQueryMsg), &out_dir, "QueryMsg");
+    // export_schema_with_title(&schema_for!(AdapterQueryMsg), &out_dir, "QueryMsg");
 }

--- a/contracts/native/module-factory/src/commands.rs
+++ b/contracts/native/module-factory/src/commands.rs
@@ -67,7 +67,7 @@ pub fn execute_create_module(
             CREATE_APP_RESPONSE_ID,
             new_module.info,
         ),
-        ModuleReference::Api(addr) => {
+        ModuleReference::Adapter(addr) => {
             let module_id = new_module.info.id_with_version();
             let register_msg: CosmosMsg<Empty> = wasm_execute(
                 account_base.manager.into_string(),

--- a/contracts/native/version-control/examples/schema.rs
+++ b/contracts/native/version-control/examples/schema.rs
@@ -8,29 +8,4 @@ fn main() {
         execute: ExecuteMsg,
         migrate: MigrateMsg,
     };
-    // let mut out_dir = current_dir().unwrap();
-    // out_dir.push("schema");
-    // create_dir_all(&out_dir).unwrap();
-    // remove_schemas(&out_dir).unwrap();
-
-    // export_schema(&schema_for!(InstantiateMsg), &out_dir);
-    // export_schema(&schema_for!(ExecuteMsg), &out_dir);
-    // export_schema(&schema_for!(QueryMsg), &out_dir);
-    // export_schema(&schema_for!(ModuleInfo), &out_dir);
-    // // export_schema(&schema_for!(EnabledModulesResponse), &out_dir);
-    // export_schema_with_title(&schema_for!(CodeIdResponse), &out_dir, "CodeIdResponse");
-    // export_schema_with_title(&schema_for!(ConfigResponse), &out_dir, "ConfigResponse");
-    // export_schema_with_title(
-    //     &schema_for!(ApiAddressesResponse),
-    //     &out_dir,
-    //     "ApiAddressesResponse",
-    // );
-    // export_schema_with_title(
-    //     &schema_for!(ApiAddressResponse),
-    //     &out_dir,
-    //     "ApiAddressResponse",
-    // );
-    // export_schema_with_title(&schema_for!(CodeIdResponse), &out_dir, "CodeIdResponse");
-    // export_schema_with_title(&schema_for!(CodeIdsResponse), &out_dir, "CodeIdsResponse");
-    // export_schema_with_title(&schema_for!(AccountBaseResponse), &out_dir, "AccountBaseResponse");
 }

--- a/contracts/testing/Cargo.toml
+++ b/contracts/testing/Cargo.toml
@@ -37,4 +37,4 @@ account-factory = { path = "../native/account-factory" }
 module-factory = { path = "../native/module-factory" }
 version-control = { path = "../native/version-control" }
 subscription = { path = "../modules/apps/subscription" }
-dex = { path = "../modules/apis/dex" }
+dex = { path = "../modules/adapters/dex" }

--- a/contracts/testing/src/tests/manager.rs
+++ b/contracts/testing/src/tests/manager.rs
@@ -3,7 +3,7 @@ use super::{
     testing_infrastructure::env::{get_account_state, mock_app, register_api, AbstractEnv},
 };
 use abstract_sdk::core::objects::module::ModuleVersion;
-use abstract_sdk::core::{api, api::BaseInstantiateMsg, manager as ManagerMsgs};
+use abstract_sdk::core::{adapter::BaseInstantiateMsg, api, manager as ManagerMsgs};
 use abstract_sdk::core::{objects::module::ModuleInfo, EXCHANGE};
 use anyhow::Result as AnyResult;
 use cosmwasm_std::{to_binary, Addr, Empty};
@@ -28,17 +28,17 @@ pub fn register_and_create_dex_api(
         dex::contract::query,
     ));
     let code_id = app.store_code(contract);
-    let msg = api::InstantiateMsg {
+    let msg = adapter::InstantiateMsg {
         base: BaseInstantiateMsg {
             ans_host_address: ans_host.to_string(),
             version_control_address: version_control.to_string(),
         },
         app: Empty {},
     };
-    let api_addr = app
+    let adapter_addr = app
         .instantiate_contract(code_id, sender.clone(), &msg, &[], "api".to_owned(), None)
         .unwrap();
-    register_api(app, sender, version_control, module, api_addr).unwrap();
+    register_api(app, sender, version_control, module, adapter_addr).unwrap();
     Ok(())
 }
 
@@ -68,7 +68,7 @@ fn proper_initialization() {
         &ManagerMsgs::ExecuteMsg::InstallModule {
             module: ModuleInfo::from_id(EXCHANGE, ModuleVersion::Latest).unwrap(),
             init_msg: Some(
-                to_binary(&api::InstantiateMsg {
+                to_binary(&adapter::InstantiateMsg {
                     base: BaseInstantiateMsg {
                         ans_host_address: env.native_contracts.ans_host.to_string(),
                         version_control_address: env.native_contracts.version_control.to_string(),

--- a/development/VERSIONING.md
+++ b/development/VERSIONING.md
@@ -12,12 +12,16 @@ The versioning setup is based on the dependency graph of the project, which is s
 
 Form the graph we can draw some conclusions:
 
-1. `abstract-api` and `abstract-app` depend on `abstract-boot` and are the top-level packages within Abstract. Hence they can be independently versioned.
-2. `abstract-boot` depends on all the contracts in the repository. The contracts should share their version with `abstract-boot`.
+1. `abstract-adapter` and `abstract-app` depend on `abstract-boot` and are the top-level packages within Abstract. Hence
+   they can be independently versioned.
+2. `abstract-boot` depends on all the contracts in the repository. The contracts should share their version
+   with `abstract-boot`.
 
 ## Versioning
 
-Most of the versioning information is contained within the workspace level [`Cargo.toml`](./Cargo.toml). The version defined in the `[workspace]` section is used as the version for all contracts in the workspace, as well as the lower level packages. The only exceptions are `abstract-api` and `abstract-app`, which can be versioned independently.
+Most of the versioning information is contained within the workspace level [`Cargo.toml`](./Cargo.toml). The version
+defined in the `[workspace]` section is used as the version for all contracts in the workspace, as well as the lower
+level packages. The only exceptions are `abstract-adapter` and `abstract-app`, which can be versioned independently.
 
 ## Updating Dependencies
 
@@ -35,7 +39,7 @@ Most of the versioning information is contained within the workspace level [`Car
 
 ### Modules
 
-1. Upgrade the Abstract packages in the [`apis`](https://github.com/AbstractSDK/apis) repository to the new version in
+1. Upgrade the Abstract packages in the [`adapters`](https://github.com/AbstractSDK/adapters) repository to the new version in
    the base Cargo.toml
 2. Run just publish
 3. Upgrade the Abstract packages in the [`apps`](https://github.com/AbstractSDK/apps) repository to the new version in

--- a/docs/IBC.md
+++ b/docs/IBC.md
@@ -3,7 +3,7 @@
 The Abstract IBC architecture aims to provide developers with a set of Abstract-SDK supported actions to simplify IBC usage. 
 
 # Message flow
-IBC actions are instantiated in a custom contract (with proxy execute permissions) or an installed api/app. They result
+IBC actions are instantiated in a custom contract (with proxy execute permissions) or an installed adapter/app. They result
 in a call to the Account's proxy contract on the `ExecuteMsg::IbcAction { msgs: Vec<IbcClientMsg> }` endpoint.
 
 These `IbcClientMsg` messages are then called on the Account's client contract. Note that the client contract must be enabled
@@ -40,7 +40,7 @@ pub struct IbcResponseMsg {
 
 The response ID can then be matched in the receiving contract to identify the action that has finished, along with
 parsing the Binary response for successful actions.
-This functionality is already provided by the app and api contract implementations.
+This functionality is already provided by the app and adapter contract implementations.
 
 > Abstract's packages provide an easy entrypoint to this functionality.
 

--- a/docs/Publishing.md
+++ b/docs/Publishing.md
@@ -20,4 +20,4 @@ file.
 3. `abstract-sdk`
 4. All contracts in `./contracts`
 5. `abstract-boot`
-6. `abstract-api`, `abstract-app` and `abstract-ibc-host`
+6. `abstract-adapter`, `abstract-app` and `abstract-ibc-host`

--- a/packages/abstract-adapter/Cargo.toml
+++ b/packages/abstract-adapter/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "abstract-api"
+name = "abstract-adapter"
 version = "0.14.3"
 authors = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
-description = "base api contract implementation"
+description = "base adapter contract implementation"
 resolver = "2"
 
 
@@ -35,4 +35,4 @@ abstract-boot = { version = "0.14.3", workspace = true, optional = true }
 [dev-dependencies]
 speculoos = { workspace = true }
 cosmwasm-schema = { workspace = true }
-abstract-api = { path = ".", features = ["test-utils"] }
+abstract-adapter = { path = ".", features = ["test-utils"] }

--- a/packages/abstract-adapter/README.md
+++ b/packages/abstract-adapter/README.md
@@ -1,0 +1,3 @@
+# Abstract Adapter
+
+The Abstract Adapter base is a contract framework for non-migratable contracts with account execution privileges.

--- a/packages/abstract-adapter/src/endpoints.rs
+++ b/packages/abstract-adapter/src/endpoints.rs
@@ -71,7 +71,7 @@ macro_rules! export_endpoints {
 #[cfg(test)]
 mod test {
     use crate::mock::*;
-    use abstract_core::api::{self, ApiRequestMsg};
+    use abstract_core::adapter::{self, AdapterRequestMsg};
     use abstract_sdk::base::{
         ExecuteEndpoint, InstantiateEndpoint, QueryEndpoint, ReplyEndpoint, SudoEndpoint,
     };
@@ -84,13 +84,13 @@ mod test {
 
     #[test]
     fn exports_endpoints() {
-        export_endpoints!(MOCK_API, MockApiContract);
+        export_endpoints!(MOCK_ADAPTER, MockAdapterContract);
 
         let mut deps = mock_dependencies();
 
         // init
-        let init_msg = api::InstantiateMsg {
-            base: api::BaseInstantiateMsg {
+        let init_msg = adapter::InstantiateMsg {
+            base: adapter::BaseInstantiateMsg {
                 ans_host_address: TEST_ANS_HOST.to_string(),
                 version_control_address: TEST_VERSION_CONTROL.to_string(),
             },
@@ -102,7 +102,7 @@ mod test {
             mock_info(TEST_ADMIN, &[]),
             init_msg.clone(),
         );
-        let expected_init = MOCK_API.instantiate(
+        let expected_init = MOCK_ADAPTER.instantiate(
             deps.as_mut(),
             mock_env(),
             mock_info(TEST_ADMIN, &[]),
@@ -111,14 +111,14 @@ mod test {
         assert_that!(actual_init).is_equal_to(expected_init);
 
         // exec
-        let exec_msg = api::ExecuteMsg::Module(ApiRequestMsg::new(None, MockExecMsg));
+        let exec_msg = adapter::ExecuteMsg::Module(AdapterRequestMsg::new(None, MockExecMsg));
         let actual_exec = execute(
             deps.as_mut(),
             mock_env(),
             mock_info(TEST_ADMIN, &[]),
             exec_msg.clone(),
         );
-        let expected_exec = MOCK_API.execute(
+        let expected_exec = MOCK_ADAPTER.execute(
             deps.as_mut(),
             mock_env(),
             mock_info(TEST_ADMIN, &[]),
@@ -127,15 +127,15 @@ mod test {
         assert_that!(actual_exec).is_equal_to(expected_exec);
 
         // query
-        let query_msg = api::QueryMsg::Module(MockQueryMsg);
+        let query_msg = adapter::QueryMsg::Module(MockQueryMsg);
         let actual_query = query(deps.as_ref(), mock_env(), query_msg.clone());
-        let expected_query = MOCK_API.query(deps.as_ref(), mock_env(), query_msg);
+        let expected_query = MOCK_ADAPTER.query(deps.as_ref(), mock_env(), query_msg);
         assert_that!(actual_query).is_equal_to(expected_query);
 
         // sudo
         let sudo_msg = MockSudoMsg {};
         let actual_sudo = sudo(deps.as_mut(), mock_env(), sudo_msg.clone());
-        let expected_sudo = MOCK_API.sudo(deps.as_mut(), mock_env(), sudo_msg);
+        let expected_sudo = MOCK_ADAPTER.sudo(deps.as_mut(), mock_env(), sudo_msg);
         assert_that!(actual_sudo).is_equal_to(expected_sudo);
 
         // reply
@@ -144,7 +144,7 @@ mod test {
             result: SubMsgResult::Err("test".into()),
         };
         let actual_reply = reply(deps.as_mut(), mock_env(), reply_msg.clone());
-        let expected_reply = MOCK_API.reply(deps.as_mut(), mock_env(), reply_msg);
+        let expected_reply = MOCK_ADAPTER.reply(deps.as_mut(), mock_env(), reply_msg);
         assert_that!(actual_reply).is_equal_to(expected_reply);
     }
 }

--- a/packages/abstract-adapter/src/endpoints/ibc_callback.rs
+++ b/packages/abstract-adapter/src/endpoints/ibc_callback.rs
@@ -1,9 +1,9 @@
-use crate::{state::ContractError, ApiContract};
+use crate::{state::ContractError, AdapterContract};
 use abstract_sdk::base::IbcCallbackEndpoint;
 
 impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
     IbcCallbackEndpoint
-    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
 }
 
@@ -11,17 +11,17 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
 
 // #[cfg(test)]
 // mod tests {
-//     use abstract_core::{api::{ExecuteMsg, BaseExecuteMsg, self}, abstract_ica::IbcResponseMsg};
+//     use abstract_core::{adapter::{ExecuteMsg, BaseExecuteMsg, self}, abstract_ica::IbcResponseMsg};
 //     use abstract_sdk::base::ExecuteEndpoint;
 //     use abstract_testing::prelude::{TEST_MANAGER, mocked_account_querier_builder};
 //     use cosmwasm_std::{testing::{mock_dependencies, mock_env, mock_info}, DepsMut, Response};
 //     use speculoos::prelude::*;
-//     use crate::mock::{ApiMockResult, MockReceiveMsg, execute, MOCK_API, mock_init, MockExecMsg, MockError};
+//     use crate::mock::{ApiMockResult, MockReceiveMsg, execute, MOCK_ADAPTER, mock_init, MockExecMsg, MockError};
 
 //     fn setup_with_traders(mut deps: DepsMut, traders: Vec<&str>) {
 //         mock_init(deps.branch()).unwrap();
 
-//         let _api = MOCK_API;
+//         let _api = MOCK_ADAPTER;
 //         let msg = BaseExecuteMsg::UpdateTraders {
 //             to_add: traders.into_iter().map(Into::into).collect(),
 //             to_remove: vec![],
@@ -35,7 +35,7 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
 //         sender: &str,
 //         msg: ExecuteMsg<MockExecMsg, MockReceiveMsg>,
 //     ) -> Result<Response, MockError> {
-//         MOCK_API.execute(deps, mock_env(), mock_info(sender, &[]), msg)
+//         MOCK_ADAPTER.execute(deps, mock_env(), mock_info(sender, &[]), msg)
 //     }
 
 //     fn base_execute_as(
@@ -43,7 +43,7 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
 //         sender: &str,
 //         msg: BaseExecuteMsg,
 //     ) -> Result<Response, MockError> {
-//         execute_as(deps, sender, api::ExecuteMsg::Base(msg))
+//         execute_as(deps, sender, adapter::ExecuteMsg::Base(msg))
 //     }
 
 //     #[test]

--- a/packages/abstract-adapter/src/endpoints/instantiate.rs
+++ b/packages/abstract-adapter/src/endpoints/instantiate.rs
@@ -1,5 +1,5 @@
-use crate::state::{ApiContract, ApiState, ContractError};
-use abstract_core::{api::InstantiateMsg, objects::module_version::set_module_data};
+use crate::state::{AdapterContract, ApiState, ContractError};
+use abstract_core::{adapter::InstantiateMsg, objects::module_version::set_module_data};
 use abstract_sdk::{
     base::{Handler, InstantiateEndpoint},
     feature_objects::AnsHost,
@@ -17,7 +17,7 @@ impl<
         ReceiveMsg,
         SudoMsg,
     > InstantiateEndpoint
-    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
     type InstantiateMsg = InstantiateMsg<CustomInitMsg>;
     /// Instantiate the api
@@ -52,7 +52,7 @@ impl<
 #[cfg(test)]
 mod tests {
     use abstract_core::{
-        api::{BaseInstantiateMsg, InstantiateMsg},
+        adapter::{BaseInstantiateMsg, InstantiateMsg},
         objects::module_version::{ModuleData, MODULE},
     };
     use abstract_sdk::{base::InstantiateEndpoint, feature_objects::AnsHost};
@@ -64,14 +64,14 @@ mod tests {
     use speculoos::prelude::*;
 
     use crate::{
-        mock::{ApiMockResult, MockInitMsg, MOCK_API, MOCK_DEP, TEST_METADATA},
+        mock::{AdapterMockResult, MockInitMsg, MOCK_ADAPTER, MOCK_DEP, TEST_METADATA},
         state::ApiState,
     };
     use abstract_testing::prelude::*;
 
     #[test]
-    fn successful() -> ApiMockResult {
-        let api = MOCK_API.with_dependencies(&[MOCK_DEP]);
+    fn successful() -> AdapterMockResult {
+        let api = MOCK_ADAPTER.with_dependencies(&[MOCK_DEP]);
         let env = mock_env();
         let info = mock_info(TEST_MANAGER, &[]);
         let mut deps = mock_dependencies();
@@ -102,7 +102,7 @@ mod tests {
             version: TEST_VERSION.into(),
         });
 
-        let api = MOCK_API;
+        let api = MOCK_ADAPTER;
         let none_authorized = api.authorized_addresses.is_empty(&deps.storage);
         assert!(none_authorized);
 
@@ -117,8 +117,8 @@ mod tests {
     }
 
     #[test]
-    fn invalid_ans_host() -> ApiMockResult {
-        let api = MOCK_API;
+    fn invalid_ans_host() -> AdapterMockResult {
+        let api = MOCK_ADAPTER;
         let env = mock_env();
         let info = mock_info(TEST_MANAGER, &[]);
         let mut deps = mock_dependencies();
@@ -138,8 +138,8 @@ mod tests {
     }
 
     #[test]
-    fn invalid_version_control() -> ApiMockResult {
-        let api = MOCK_API;
+    fn invalid_version_control() -> AdapterMockResult {
+        let api = MOCK_ADAPTER;
         let env = mock_env();
         let info = mock_info(TEST_MANAGER, &[]);
         let mut deps = mock_dependencies();

--- a/packages/abstract-adapter/src/endpoints/query.rs
+++ b/packages/abstract-adapter/src/endpoints/query.rs
@@ -1,21 +1,21 @@
-use crate::state::{ApiContract, ContractError};
-use abstract_core::api::{
-    ApiConfigResponse, ApiQueryMsg, AuthorizedAddressesResponse, BaseQueryMsg, QueryMsg,
+use crate::state::{AdapterContract, ContractError};
+use abstract_core::adapter::{
+    AdapterConfigResponse, AdapterQueryMsg, AuthorizedAddressesResponse, BaseQueryMsg, QueryMsg,
 };
 use abstract_sdk::base::{Handler, QueryEndpoint};
 use cosmwasm_std::{to_binary, Addr, Binary, Deps, Env, StdResult};
 
-/// Where we dispatch the queries for the ApiContract
-/// These ApiQueryMsg declarations can be found in `abstract_sdk::core::common_module::app_msg`
+/// Where we dispatch the queries for the AdapterContract
+/// These AdapterQueryMsg declarations can be found in `abstract_sdk::core::common_module::app_msg`
 impl<
         Error: ContractError,
         CustomInitMsg,
         CustomExecMsg,
-        CustomQueryMsg: ApiQueryMsg,
+        CustomQueryMsg: AdapterQueryMsg,
         ReceiveMsg,
         SudoMsg,
     > QueryEndpoint
-    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
     type QueryMsg = QueryMsg<CustomQueryMsg>;
     fn query(&self, deps: Deps, env: Env, msg: Self::QueryMsg) -> Result<Binary, Error> {
@@ -27,7 +27,7 @@ impl<
 }
 
 impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
-    ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
     fn base_query(&self, deps: Deps, _env: Env, query: BaseQueryMsg) -> Result<Binary, Error> {
         match query {
@@ -49,9 +49,9 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
         }
     }
 
-    fn dapp_config(&self, deps: Deps) -> StdResult<ApiConfigResponse> {
+    fn dapp_config(&self, deps: Deps) -> StdResult<AdapterConfigResponse> {
         let state = self.base_state.load(deps.storage)?;
-        Ok(ApiConfigResponse {
+        Ok(AdapterConfigResponse {
             version_control_address: state.version_control,
             ans_host_address: state.ans_host.address,
             dependencies: self

--- a/packages/abstract-adapter/src/endpoints/receive.rs
+++ b/packages/abstract-adapter/src/endpoints/receive.rs
@@ -1,21 +1,21 @@
-use crate::state::{ApiContract, ContractError};
+use crate::state::{AdapterContract, ContractError};
 use abstract_sdk::base::ReceiveEndpoint;
 
 impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
     ReceiveEndpoint
-    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::mock::{execute, ApiMockResult, MockReceiveMsg};
-    use abstract_core::api::ExecuteMsg;
+    use crate::mock::{execute, AdapterMockResult, MockReceiveMsg};
+    use abstract_core::adapter::ExecuteMsg;
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
     use speculoos::prelude::*;
 
     #[test]
-    fn endpoint() -> ApiMockResult {
+    fn endpoint() -> AdapterMockResult {
         let env = mock_env();
         let info = mock_info("sender", &[]);
         let mut deps = mock_dependencies();

--- a/packages/abstract-adapter/src/endpoints/reply.rs
+++ b/packages/abstract-adapter/src/endpoints/reply.rs
@@ -1,16 +1,16 @@
 use abstract_sdk::base::ReplyEndpoint;
 
-use crate::{state::ContractError, ApiContract};
+use crate::{state::ContractError, AdapterContract};
 
 impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
     ReplyEndpoint
-    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::mock::{reply, ApiMockResult};
+    use crate::mock::{reply, AdapterMockResult};
     use abstract_sdk::AbstractSdkError;
     use cosmwasm_std::{
         testing::{mock_dependencies, mock_env},
@@ -19,7 +19,7 @@ mod tests {
     use speculoos::prelude::*;
 
     #[test]
-    fn endpoint() -> ApiMockResult {
+    fn endpoint() -> AdapterMockResult {
         let env = mock_env();
         let mut deps = mock_dependencies();
         deps.querier = abstract_testing::mock_querier();
@@ -38,7 +38,7 @@ mod tests {
     }
 
     #[test]
-    fn no_matching_id() -> ApiMockResult {
+    fn no_matching_id() -> AdapterMockResult {
         let env = mock_env();
         let mut deps = mock_dependencies();
         deps.querier = abstract_testing::mock_querier();

--- a/packages/abstract-adapter/src/endpoints/sudo.rs
+++ b/packages/abstract-adapter/src/endpoints/sudo.rs
@@ -1,21 +1,21 @@
 use abstract_sdk::base::SudoEndpoint;
 
-use crate::{state::ContractError, ApiContract};
+use crate::{state::ContractError, AdapterContract};
 
 impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
     SudoEndpoint
-    for ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::mock::{sudo, ApiMockResult};
+    use crate::mock::{sudo, AdapterMockResult};
     use cosmwasm_std::testing::{mock_dependencies, mock_env};
     use speculoos::prelude::*;
 
     #[test]
-    fn endpoint() -> ApiMockResult {
+    fn endpoint() -> AdapterMockResult {
         let env = mock_env();
         let mut deps = mock_dependencies();
         deps.querier = abstract_testing::mock_querier();

--- a/packages/abstract-adapter/src/error.rs
+++ b/packages/abstract-adapter/src/error.rs
@@ -3,18 +3,18 @@ use cosmwasm_std::StdError;
 use thiserror::Error;
 
 #[derive(Error, Debug, PartialEq)]
-pub enum ApiError {
+pub enum AdapterError {
     #[error("{0}")]
     Std(#[from] StdError),
 
     #[error(transparent)]
     AbstractSdk(#[from] AbstractSdkError),
 
-    #[error("Sender: {sender} of request to {api} is not a Manager")]
-    UnauthorizedApiRequest { api: String, sender: String },
+    #[error("Sender: {sender} of request to {adapter} is not a Manager")]
+    UnauthorizedAdapterRequest { adapter: String, sender: String },
 
-    #[error("Sender: {sender} of request to {api} is not a Manager or Authorized Address")]
-    UnauthorizedAddressApiRequest { api: String, sender: String },
+    #[error("Sender: {sender} of request to {adapter} is not a Manager or Authorized Address")]
+    UnauthorizedAddressAdapterRequest { adapter: String, sender: String },
 
     #[error("The authorized address to remove: {} was not present.", address)]
     AuthorizedAddressNotPresent { address: String },

--- a/packages/abstract-adapter/src/handler.rs
+++ b/packages/abstract-adapter/src/handler.rs
@@ -1,9 +1,9 @@
-use crate::{state::ContractError, ApiContract};
+use crate::{state::ContractError, AdapterContract};
 use abstract_sdk::base::{AbstractContract, Handler};
 use cosmwasm_std::Empty;
 
 impl<Error: ContractError, InitMsg, ExecMsg, QueryMsg, ReceiveMsg, SudoMsg> Handler
-    for ApiContract<Error, InitMsg, ExecMsg, QueryMsg, ReceiveMsg, SudoMsg>
+    for AdapterContract<Error, InitMsg, ExecMsg, QueryMsg, ReceiveMsg, SudoMsg>
 {
     type Error = Error;
     type CustomInitMsg = InitMsg;

--- a/packages/abstract-adapter/src/schema.rs
+++ b/packages/abstract-adapter/src/schema.rs
@@ -5,25 +5,25 @@ use cosmwasm_std::Empty;
 use schemars::JsonSchema;
 use serde::Serialize;
 
-use abstract_core::api::{ApiExecuteMsg, ApiQueryMsg};
+use abstract_core::adapter::{AdapterExecuteMsg, AdapterQueryMsg};
 use abstract_sdk::{
     base::{ExecuteEndpoint, InstantiateEndpoint, QueryEndpoint},
-    core::api::{ApiConfigResponse, AuthorizedAddressesResponse},
+    core::adapter::{AdapterConfigResponse, AuthorizedAddressesResponse},
 };
 
-use crate::{ApiContract, ApiError};
+use crate::{AdapterContract, AdapterError};
 
 impl<
         Error: From<cosmwasm_std::StdError>
-            + From<ApiError>
+            + From<AdapterError>
             + From<abstract_sdk::AbstractSdkError>
             + 'static,
-        CustomExecMsg: Serialize + JsonSchema + ApiExecuteMsg,
+        CustomExecMsg: Serialize + JsonSchema + AdapterExecuteMsg,
         CustomInitMsg: Serialize + JsonSchema,
-        CustomQueryMsg: Serialize + JsonSchema + ApiQueryMsg + QueryResponses,
+        CustomQueryMsg: Serialize + JsonSchema + AdapterQueryMsg + QueryResponses,
         ReceiveMsg: Serialize + JsonSchema,
         SudoMsg,
-    > ApiContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
+    > AdapterContract<Error, CustomInitMsg, CustomExecMsg, CustomQueryMsg, ReceiveMsg, SudoMsg>
 {
     pub fn export_schema(out_dir: &Path) {
         // write out the module schema
@@ -55,6 +55,10 @@ impl<
             out_dir,
             "AuthorizedAddressesResponse",
         );
-        export_schema_with_title(&schema_for!(ApiConfigResponse), out_dir, "ConfigResponse");
+        export_schema_with_title(
+            &schema_for!(AdapterConfigResponse),
+            out_dir,
+            "ConfigResponse",
+        );
     }
 }

--- a/packages/abstract-api/README.md
+++ b/packages/abstract-api/README.md
@@ -1,3 +1,0 @@
-# Abstract Api
-
-The Abstract API base is a contract framework for non-migratable contracts with account execution privileges.

--- a/packages/abstract-boot/src/account/manager.rs
+++ b/packages/abstract-boot/src/account/manager.rs
@@ -1,6 +1,6 @@
 pub use abstract_core::manager::{ExecuteMsgFns as ManagerExecFns, QueryMsgFns as ManagerQueryFns};
 use abstract_core::{
-    api,
+    adapter,
     manager::*,
     objects::module::{ModuleInfo, ModuleVersion},
 };
@@ -81,7 +81,7 @@ impl<Chain: CwEnv> Manager<Chain> {
         Ok(())
     }
 
-    pub fn update_api_authorized_addresses(
+    pub fn update_adapter_authorized_addresses(
         &self,
         module_id: &str,
         to_add: Vec<String>,
@@ -89,10 +89,9 @@ impl<Chain: CwEnv> Manager<Chain> {
     ) -> Result<(), crate::AbstractBootError> {
         self.execute_on_module(
             module_id,
-            api::ExecuteMsg::<Empty, Empty>::Base(api::BaseExecuteMsg::UpdateAuthorizedAddresses {
-                to_add,
-                to_remove,
-            }),
+            adapter::ExecuteMsg::<Empty, Empty>::Base(
+                adapter::BaseExecuteMsg::UpdateAuthorizedAddresses { to_add, to_remove },
+            ),
         )?;
 
         Ok(())

--- a/packages/abstract-boot/src/deployers.rs
+++ b/packages/abstract-boot/src/deployers.rs
@@ -5,10 +5,10 @@ use boot_core::{BootError::StdErr, CwEnv, Deploy, *};
 use semver::Version;
 use serde::Serialize;
 
-/// Trait for deploying APIs
-pub trait ApiDeployer<Chain: CwEnv, CustomInitMsg: Serialize>:
+/// Trait for deploying Adapters
+pub trait AdapterDeployer<Chain: CwEnv, CustomInitMsg: Serialize>:
     ContractInstance<Chain>
-    + BootInstantiate<Chain, InstantiateMsg = abstract_core::api::InstantiateMsg<CustomInitMsg>>
+    + BootInstantiate<Chain, InstantiateMsg = abstract_core::adapter::InstantiateMsg<CustomInitMsg>>
     + BootUpload<Chain>
 {
     fn deploy(
@@ -22,11 +22,11 @@ pub trait ApiDeployer<Chain: CwEnv, CustomInitMsg: Serialize>:
         // check for existing version
         let version_check = abstr
             .version_control
-            .get_api_addr(&self.id(), ModuleVersion::from(version.to_string()));
+            .get_adapter_addr(&self.id(), ModuleVersion::from(version.to_string()));
 
         if version_check.is_ok() {
             return Err(StdErr(format!(
-                "API {} already exists with version {}",
+                "Adapter {} already exists with version {}",
                 self.id(),
                 version
             ))
@@ -34,9 +34,9 @@ pub trait ApiDeployer<Chain: CwEnv, CustomInitMsg: Serialize>:
         };
 
         self.upload()?;
-        let init_msg = abstract_core::api::InstantiateMsg {
+        let init_msg = abstract_core::adapter::InstantiateMsg {
             module: custom_init_msg,
-            base: abstract_core::api::BaseInstantiateMsg {
+            base: abstract_core::adapter::BaseInstantiateMsg {
                 ans_host_address: abstr.ans_host.address()?.into(),
                 version_control_address: abstr.version_control.address()?.into(),
             },
@@ -45,7 +45,7 @@ pub trait ApiDeployer<Chain: CwEnv, CustomInitMsg: Serialize>:
 
         abstr
             .version_control
-            .register_apis(vec![self.as_instance()], &version)?;
+            .register_adapters(vec![self.as_instance()], &version)?;
         Ok(())
     }
 }

--- a/packages/abstract-boot/src/native/module_factory.rs
+++ b/packages/abstract-boot/src/native/module_factory.rs
@@ -1,6 +1,6 @@
 use abstract_core::module_factory::*;
 
-// use crate::api::get_api_init_msgs;
+// use crate::adapter::get_adapter_init_msgs;
 use boot_core::{Contract, CwEnv, TxResponse};
 
 pub use abstract_core::module_factory::{
@@ -33,7 +33,7 @@ impl<Chain: CwEnv> ModuleFactory<Chain> {
     }
 
     // pub  fn save_init_binaries(&self, mem_addr: String, version_control_addr: String) -> Result<(), crate::AbstractBootError> {
-    //     let msgs = get_api_init_msgs(mem_addr,version_control_addr);
+    //     let msgs = get_adapter_init_msgs(mem_addr,version_control_addr);
     //     // TODO: Add version management support
     //     let binaries = msgs
     //         .iter()

--- a/packages/abstract-boot/src/native/version_control.rs
+++ b/packages/abstract-boot/src/native/version_control.rs
@@ -104,13 +104,13 @@ where
         Ok(())
     }
 
-    pub fn register_apis(
+    pub fn register_adapters(
         &self,
-        apis: Vec<&Contract<Chain>>,
+        adapters: Vec<&Contract<Chain>>,
         version: &Version,
     ) -> Result<(), crate::AbstractBootError> {
-        let to_register = self.contracts_into_module_entries(apis, version, |c| {
-            ModuleReference::Api(c.address().unwrap())
+        let to_register = self.contracts_into_module_entries(adapters, version, |c| {
+            ModuleReference::Adapter(c.address().unwrap())
         })?;
         self.propose_modules(to_register)?;
         Ok(())
@@ -160,15 +160,15 @@ where
         Ok(resp.account_base)
     }
 
-    /// Retrieves an API's address from version control given the module **id** and **version**.
-    pub fn get_api_addr(
+    /// Retrieves an Adapter's address from version control given the module **id** and **version**.
+    pub fn get_adapter_addr(
         &self,
         id: &str,
         version: ModuleVersion,
     ) -> Result<Addr, crate::AbstractBootError> {
         let module: Module = self.module(ModuleInfo::from_id(id, version)?)?;
 
-        Ok(module.reference.unwrap_api()?)
+        Ok(module.reference.unwrap_adapter()?)
     }
 
     /// Retrieves an APP's code id from version control given the module **id** and **version**.
@@ -230,7 +230,7 @@ impl VersionControl<Daemon> {
     //     Ok(())
     // }
 
-    // pub fn update_apis(&self) -> anyhow::Result<()> {
+    // pub fn update_adapters(&self) -> anyhow::Result<()> {
     //     for contract_name in chain_state.keys() {
     //         if !API_CONTRACTS.contains(&contract_name.as_str()) {
     //             continue;

--- a/packages/abstract-core/src/adapter.rs
+++ b/packages/abstract-core/src/adapter.rs
@@ -1,11 +1,11 @@
 //! # Abstract Api Base
 //!
-//! `abstract_core::api` implements shared functionality that's useful for creating new Abstract apis.
+//! `abstract_core::adapter` implements shared functionality that's useful for creating new Abstract adapters.
 //!
 //! ## Description
-//! An Abstract api contract is a contract that is allowed to perform actions on a [proxy](crate::proxy) contract.
+//! An Abstract adapter contract is a contract that is allowed to perform actions on a [proxy](crate::proxy) contract.
 //! It is not migratable and its functionality is shared between users, meaning that all users call the same contract address to perform operations on the Account.
-//! The api structure is well-suited for implementing standard interfaces to external services like dexes, lending platforms, etc.
+//! The adapter structure is well-suited for implementing standard interfaces to external services like dexes, lending platforms, etc.
 
 use crate::base::{
     ExecuteMsg as MiddlewareExecMsg, InstantiateMsg as MiddlewareInstantiateMsg,
@@ -16,7 +16,7 @@ use cosmwasm_std::{Addr, Empty};
 use serde::Serialize;
 
 pub type ExecuteMsg<Request = Empty, ReceiveMsg = Empty> =
-    MiddlewareExecMsg<BaseExecuteMsg, ApiRequestMsg<Request>, ReceiveMsg>;
+    MiddlewareExecMsg<BaseExecuteMsg, AdapterRequestMsg<Request>, ReceiveMsg>;
 pub type QueryMsg<ModuleMsg = Empty> = MiddlewareQueryMsg<BaseQueryMsg, ModuleMsg>;
 pub type InstantiateMsg<ModuleMsg = Empty> =
     MiddlewareInstantiateMsg<BaseInstantiateMsg, ModuleMsg>;
@@ -24,31 +24,31 @@ pub type InstantiateMsg<ModuleMsg = Empty> =
 /// Trait indicates that the type is used as an app message
 /// in the [`ExecuteMsg`] enum.
 /// Enables [`Into<ExecuteMsg>`] for BOOT fn-generation support.
-pub trait ApiExecuteMsg: Serialize {}
+pub trait AdapterExecuteMsg: Serialize {}
 
-impl<T: ApiExecuteMsg, R: Serialize> From<T> for ExecuteMsg<T, R> {
-    fn from(api_msg: T) -> Self {
-        Self::Module(ApiRequestMsg {
+impl<T: AdapterExecuteMsg, R: Serialize> From<T> for ExecuteMsg<T, R> {
+    fn from(adapter_msg: T) -> Self {
+        Self::Module(AdapterRequestMsg {
             proxy_address: None,
-            request: api_msg,
+            request: adapter_msg,
         })
     }
 }
 
-impl ApiExecuteMsg for Empty {}
+impl AdapterExecuteMsg for Empty {}
 
 /// Trait indicates that the type is used as an api message
 /// in the [`QueryMsg`] enum.
 /// Enables [`Into<QueryMsg>`] for BOOT fn-generation support.
-pub trait ApiQueryMsg: Serialize {}
+pub trait AdapterQueryMsg: Serialize {}
 
-impl<T: ApiQueryMsg> From<T> for QueryMsg<T> {
+impl<T: AdapterQueryMsg> From<T> for QueryMsg<T> {
     fn from(app: T) -> Self {
         Self::Module(app)
     }
 }
 
-impl ApiQueryMsg for Empty {}
+impl AdapterQueryMsg for Empty {}
 
 /// Used by Abstract to instantiate the contract
 /// The contract is then registered on the version control contract using [`crate::version_control::ExecuteMsg::ProposeModules`].
@@ -63,29 +63,29 @@ pub struct BaseInstantiateMsg {
 impl<RequestMsg, ReceiveMsg> From<BaseExecuteMsg>
     for MiddlewareExecMsg<BaseExecuteMsg, RequestMsg, ReceiveMsg>
 {
-    fn from(api_msg: BaseExecuteMsg) -> Self {
-        Self::Base(api_msg)
+    fn from(adapter_msg: BaseExecuteMsg) -> Self {
+        Self::Base(adapter_msg)
     }
 }
 
-impl<RequestMsg, Request, BaseExecMsg> From<ApiRequestMsg<RequestMsg>>
-    for MiddlewareExecMsg<BaseExecMsg, ApiRequestMsg<RequestMsg>, Request>
+impl<RequestMsg, Request, BaseExecMsg> From<AdapterRequestMsg<RequestMsg>>
+    for MiddlewareExecMsg<BaseExecMsg, AdapterRequestMsg<RequestMsg>, Request>
 {
-    fn from(request_msg: ApiRequestMsg<RequestMsg>) -> Self {
+    fn from(request_msg: AdapterRequestMsg<RequestMsg>) -> Self {
         Self::Module(request_msg)
     }
 }
 
-/// An api request.
+/// An adapter request.
 /// If proxy is None, then the sender must be an Account manager and the proxy address is extrapolated from the Account id.
 #[cosmwasm_schema::cw_serde]
-pub struct ApiRequestMsg<Request> {
+pub struct AdapterRequestMsg<Request> {
     pub proxy_address: Option<String>,
     /// The actual request
     pub request: Request,
 }
 
-impl<Request: Serialize> ApiRequestMsg<Request> {
+impl<Request: Serialize> AdapterRequestMsg<Request> {
     pub fn new(proxy_address: Option<String>, request: Request) -> Self {
         Self {
             proxy_address,
@@ -94,7 +94,7 @@ impl<Request: Serialize> ApiRequestMsg<Request> {
     }
 }
 
-/// Configuration message for the api
+/// Configuration message for the adapter
 #[cosmwasm_schema::cw_serde]
 #[cfg_attr(feature = "boot", derive(boot_core::ExecuteFns))]
 #[cfg_attr(feature = "boot", impl_into(ExecuteMsg<T>))]
@@ -105,18 +105,18 @@ pub enum BaseExecuteMsg {
         to_add: Vec<String>,
         to_remove: Vec<String>,
     },
-    /// Remove the api
+    /// Remove the adapter
     Remove {},
 }
 
-/// Query api message
+/// Query adapter message
 #[cosmwasm_schema::cw_serde]
 #[derive(QueryResponses)]
 #[cfg_attr(feature = "boot", derive(boot_core::QueryFns))]
 #[cfg_attr(feature = "boot", impl_into(QueryMsg < ModuleMsg >))]
 pub enum BaseQueryMsg {
-    /// Returns [`ApiConfigResponse`].
-    #[returns(ApiConfigResponse)]
+    /// Returns [`AdapterConfigResponse`].
+    #[returns(AdapterConfigResponse)]
     Config {},
     /// Returns [`AuthorizedAddressesResponse`].
     #[returns(AuthorizedAddressesResponse)]
@@ -128,8 +128,9 @@ impl<T> From<BaseQueryMsg> for QueryMsg<T> {
         Self::Base(base)
     }
 }
+
 #[cosmwasm_schema::cw_serde]
-pub struct ApiConfigResponse {
+pub struct AdapterConfigResponse {
     pub version_control_address: Addr,
     pub ans_host_address: Addr,
     pub dependencies: Vec<String>,

--- a/packages/abstract-core/src/error.rs
+++ b/packages/abstract-core/src/error.rs
@@ -39,8 +39,8 @@ pub enum AbstractError {
     #[error("Cannot rename contract from {} to {}", from, to)]
     ContractNameMismatch { from: String, to: String },
 
-    #[error("API {0} not installed on Account")]
-    ApiNotInstalled(String),
+    #[error("Adapter {0} not installed on Account")]
+    AdapterNotInstalled(String),
 
     #[error("App {0} not installed on Account")]
     AppNotInstalled(String),

--- a/packages/abstract-core/src/ibc_host.rs
+++ b/packages/abstract-core/src/ibc_host.rs
@@ -1,9 +1,9 @@
 //! # Abstract Api Base
 //!
-//! `abstract_core::api` implements shared functionality that's useful for creating new Abstract apis.
+//! `abstract_core::adapter` implements shared functionality that's useful for creating new Abstract adapters.
 //!
 //! ## Description
-//! An Abstract api contract is a contract that is allowed to perform actions on a [proxy](crate::proxy) contract.
+//! An Abstract adapter contract is a contract that is allowed to perform actions on a [proxy](crate::proxy) contract.
 //! It is not migratable and its functionality is shared between users, meaning that all users call the same contract address to perform operations on the Account.
 //! The api structure is well-suited for implementing standard interfaces to external services like dexes, lending platforms, etc.
 

--- a/packages/abstract-core/src/lib.rs
+++ b/packages/abstract-core/src/lib.rs
@@ -48,7 +48,7 @@ pub mod ibc_host;
 
 pub use registry::*;
 pub mod abstract_token;
-pub mod api;
+pub mod adapter;
 pub mod app;
 pub mod objects;
 pub mod registry;

--- a/packages/abstract-core/src/objects/module_reference.rs
+++ b/packages/abstract-core/src/objects/module_reference.rs
@@ -8,8 +8,8 @@ pub enum ModuleReference {
     AccountBase(u64),
     /// Native Abstract Contracts
     Native(Addr),
-    /// Installable apis
-    Api(Addr),
+    /// Installable adapters
+    Adapter(Addr),
     /// Installable apps
     App(u64),
     /// A stand-alone contract
@@ -23,7 +23,7 @@ impl ModuleReference {
             ModuleReference::Native(addr) => {
                 deps.api.addr_validate(addr.as_str())?;
             }
-            ModuleReference::Api(addr) => {
+            ModuleReference::Adapter(addr) => {
                 deps.api.addr_validate(addr.as_str())?;
             }
             _ => (),
@@ -49,9 +49,9 @@ impl ModuleReference {
         }
     }
 
-    pub fn unwrap_api(&self) -> AbstractResult<Addr> {
+    pub fn unwrap_adapter(&self) -> AbstractResult<Addr> {
         match self {
-            ModuleReference::Api(addr) => Ok(addr.clone()),
+            ModuleReference::Adapter(addr) => Ok(addr.clone()),
             _ => Err(AbstractError::Assert(
                 "module reference not an api module.".to_string(),
             )),
@@ -81,7 +81,7 @@ impl ModuleReference {
     pub fn unwrap_addr(&self) -> AbstractResult<Addr> {
         match self {
             ModuleReference::Native(addr) => Ok(addr.clone()),
-            ModuleReference::Api(addr) => Ok(addr.clone()),
+            ModuleReference::Adapter(addr) => Ok(addr.clone()),
             _ => Err(AbstractError::Assert(
                 "module reference not a native or api module.".to_string(),
             )),
@@ -100,7 +100,7 @@ mod test {
         let account_base = ModuleReference::AccountBase(1);
         assert_eq!(account_base.unwrap_account().unwrap(), 1);
         assert!(account_base.unwrap_native().is_err());
-        assert!(account_base.unwrap_api().is_err());
+        assert!(account_base.unwrap_adapter().is_err());
         assert!(account_base.unwrap_app().is_err());
         assert!(account_base.unwrap_standalone().is_err());
     }
@@ -109,19 +109,19 @@ mod test {
         let native = ModuleReference::Native(Addr::unchecked("addr"));
         assert!(native.unwrap_account().is_err());
         assert_eq!(native.unwrap_native().unwrap(), Addr::unchecked("addr"));
-        assert!(native.unwrap_api().is_err());
+        assert!(native.unwrap_adapter().is_err());
         assert!(native.unwrap_app().is_err());
         assert!(native.unwrap_standalone().is_err());
     }
 
     #[test]
-    fn api() {
-        let api = ModuleReference::Api(Addr::unchecked("addr"));
-        assert!(api.unwrap_account().is_err());
-        assert!(api.unwrap_native().is_err());
-        assert_eq!(api.unwrap_api().unwrap(), Addr::unchecked("addr"));
-        assert!(api.unwrap_app().is_err());
-        assert!(api.unwrap_standalone().is_err());
+    fn adapter() {
+        let adapter = ModuleReference::Adapter(Addr::unchecked("addr"));
+        assert!(adapter.unwrap_account().is_err());
+        assert!(adapter.unwrap_native().is_err());
+        assert_eq!(adapter.unwrap_adapter().unwrap(), Addr::unchecked("addr"));
+        assert!(adapter.unwrap_app().is_err());
+        assert!(adapter.unwrap_standalone().is_err());
     }
 
     #[test]
@@ -129,7 +129,7 @@ mod test {
         let app = ModuleReference::App(1);
         assert!(app.unwrap_account().is_err());
         assert!(app.unwrap_native().is_err());
-        assert!(app.unwrap_api().is_err());
+        assert!(app.unwrap_adapter().is_err());
         assert_eq!(app.unwrap_app().unwrap(), 1);
         assert!(app.unwrap_standalone().is_err());
     }
@@ -139,7 +139,7 @@ mod test {
         let standalone = ModuleReference::Standalone(1);
         assert!(standalone.unwrap_account().is_err());
         assert!(standalone.unwrap_native().is_err());
-        assert!(standalone.unwrap_api().is_err());
+        assert!(standalone.unwrap_adapter().is_err());
         assert!(standalone.unwrap_app().is_err());
         assert_eq!(standalone.unwrap_standalone().unwrap(), 1);
     }
@@ -148,7 +148,7 @@ mod test {
     fn unwrap_addr() {
         let native = ModuleReference::Native(Addr::unchecked("addr"));
         assert_eq!(native.unwrap_addr().unwrap(), Addr::unchecked("addr"));
-        let api = ModuleReference::Api(Addr::unchecked("addr"));
+        let api = ModuleReference::Adapter(Addr::unchecked("addr"));
         assert_eq!(api.unwrap_addr().unwrap(), Addr::unchecked("addr"));
 
         let account_base = ModuleReference::AccountBase(1);
@@ -162,7 +162,7 @@ mod test {
         let native = ModuleReference::Native(Addr::unchecked("addr"));
         assert_that!(native.validate(deps.as_ref())).is_ok();
 
-        let api = ModuleReference::Api(Addr::unchecked("addr"));
+        let api = ModuleReference::Adapter(Addr::unchecked("addr"));
         assert_that!(api.validate(deps.as_ref())).is_ok();
 
         let account_base = ModuleReference::AccountBase(1);
@@ -182,7 +182,7 @@ mod test {
         let native = ModuleReference::Native(Addr::unchecked(""));
         assert_that!(native.validate(deps.as_ref())).is_err();
 
-        let api = ModuleReference::Api(Addr::unchecked(""));
+        let api = ModuleReference::Adapter(Addr::unchecked(""));
         assert_that!(api.validate(deps.as_ref())).is_err();
     }
 }

--- a/packages/abstract-core/src/objects/module_version.rs
+++ b/packages/abstract-core/src/objects/module_version.rs
@@ -1,6 +1,6 @@
 /*!
 Most of the CW* specs are focused on the *public interfaces*
-of the module. The APIs used for `ExecuteMsg` or `QueryMsg`.
+of the module. The Adapters used for `ExecuteMsg` or `QueryMsg`.
 However, when we wish to migrate or inspect smart module info,
 we need some form of smart module information embedded on state.
 

--- a/packages/abstract-ibc-host/src/endpoints/query.rs
+++ b/packages/abstract-ibc-host/src/endpoints/query.rs
@@ -10,7 +10,7 @@ use abstract_sdk::{
 use cosmwasm_std::{to_binary, Binary, Deps, Env, Order, StdResult};
 
 /// Where we dispatch the queries for the Host
-/// These ApiQueryMsg declarations can be found in `abstract_sdk::core::common_module::app_msg`
+/// These AdapterQueryMsg declarations can be found in `abstract_sdk::core::common_module::app_msg`
 impl<
         Error: ContractError,
         CustomInitMsg,

--- a/packages/abstract-ibc-host/src/lib.rs
+++ b/packages/abstract-ibc-host/src/lib.rs
@@ -1,4 +1,4 @@
-//! # Abstract Api
+//! # Abstract Adapter
 //!
 //! Basis for an interfacing contract to an external service.
 use cosmwasm_std::{Empty, Response};
@@ -19,4 +19,4 @@ mod schema;
 pub mod state;
 
 // Default to Empty
-pub type ApiResult<C = Empty> = Result<Response<C>, HostError>;
+pub type AdapterResult<C = Empty> = Result<Response<C>, HostError>;

--- a/packages/abstract-sdk/Cargo.toml
+++ b/packages/abstract-sdk/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 [features]
 # for quicker tests, cargo test --lib
 
-# Expose MockModule for testing with other APIs
+# Expose MockModule for testing with other Adapters
 test-utils = ["dep:abstract-testing", "dep:cosmwasm-schema"]
 
 [dependencies]

--- a/packages/abstract-sdk/README.md
+++ b/packages/abstract-sdk/README.md
@@ -4,24 +4,31 @@
 
 [![](https://docs.rs/abstract-sdk/badge.svg)](https://docs.rs/abstract-sdk) [![](https://img.shields.io/crates/v/abstract-sdk)](https://crates.io/crates/abstract-sdk)
 
-This crate provides a set of modular APIs for developers to use in their [CosmWasm](https://cosmwasm.com/) smart-contracts.
+This crate provides a set of modular Adapters for developers to use in their [CosmWasm](https://cosmwasm.com/)
+smart-contracts.
 
 ## Getting started
 
-To get started with the Abstract SDK you first need to understand the basic features that we provide and how you can use those features to create composable smart-contract APIs.  
+To get started with the Abstract SDK you first need to understand the basic features that we provide and how you can use
+those features to create composable smart-contract Adapters.
 
 ### Features
 
-Abstract features are traits that can be implemented on a struct. Depending on the use-case that struct can represent a smart-contract or it can be a simple struct that just implements a single feature. Each feature unlocks a function on the object
-which allows you to retrieve some information. By composing these features it is possible to write advanced APIs that are automatically implemented on objects that support its required features.
+Abstract features are traits that can be implemented on a struct. Depending on the use-case that struct can represent a
+smart-contract or it can be a simple struct that just implements a single feature. Each feature unlocks a function on
+the object
+which allows you to retrieve some information. By composing these features it is possible to write advanced Adapters
+that are automatically implemented on objects that support its required features.
 
-### APIs
+### Adapters
 
-The Abstract APIs are objects that can only be retrieved if a contract or feature-object implements the required features/api traits. If the trait constraints for the API is met it is automatically implemented on the object and allows you to retrieve the API object.  
+The Abstract Adapters are objects that can only be retrieved if a contract or feature-object implements the required
+features/api traits. If the trait constraints for the Adapter is met it is automatically implemented on the object and
+allows you to retrieve the Adapter object.
 
 #### Example
 
-The [`Bank`](https://docs.rs/abstract-sdk/latest/abstract_sdk/apis/bank) API allows developers to transfer assets from and to the Account through their module object. We now want to use this API to create a `Splitter` API that splits the transfer of some amount of funds between a set of receivers.
+The [`Bank`](https://docs.rs/abstract-sdk/latest/abstract_sdk/apis/bank) Adapter allows developers to transfer assets from and to the Account through their module object. We now want to use this Adapter to create a `Splitter` API that splits the transfer of some amount of funds between a set of receivers.
 
 ```rust,no_run
 use abstract_sdk::{TransferInterface,AbstractSdkResult};
@@ -107,11 +114,11 @@ The API can then be used by any contract that implements its required traits, in
 To use an API either construct a [`feature object`](crate::feature_objects) or use an Abstract base contract as the starting-point of your application.  
 The available base contracts are:
 
-|  Kind          | Migratable | Installable  |
-|----------------|---------------|---------------|
-| [App](https://crates.io/crates/abstract-app) | ✅  | ✅ |
-| [API](https://crates.io/crates/abstract-api)   | ❌ | ✅ |
-| [IBC-host](https://crates.io/crates/abstract-ibc-host)   | ✅ | ❌ |
+| Kind                                                   | Migratable | Installable |
+|--------------------------------------------------------|------------|-------------|
+| [App](https://crates.io/crates/abstract-app)           | ✅          | ✅           |
+| [API](https://crates.io/crates/abstract-adapter)       | ❌          | ✅           |
+| [IBC-host](https://crates.io/crates/abstract-ibc-host) | ✅          | ❌           |
 
 Each base supports a set of endpoints that can accept custom handlers. These handlers can be added to the base using a static builder pattern.
 All the available endpoints are discussed [here](crate::base::endpoints).

--- a/packages/abstract-sdk/src/apis.rs
+++ b/packages/abstract-sdk/src/apis.rs
@@ -1,4 +1,4 @@
-pub mod api;
+pub mod adapter;
 pub mod app;
 pub mod bank;
 pub mod execution;

--- a/packages/abstract-sdk/src/base/endpoints.rs
+++ b/packages/abstract-sdk/src/base/endpoints.rs
@@ -53,7 +53,7 @@
 //! }
 //!
 //! ```
-//! Every `Base` variant or field is implemented by the base contract such as the [App](https://crates.io/crates/abstract-app), [API](https://crates.io/crates/abstract-api) and [IBC-host](https://crates.io/crates/abstract-ibc-host) contracts.
+//! Every `Base` variant or field is implemented by the base contract such as the [App](https://crates.io/crates/abstract-app), [API](https://crates.io/crates/abstract-adapter) and [IBC-host](https://crates.io/crates/abstract-ibc-host) contracts.
 //! These contracts then expose a type that requires the missing `App` variant types to be provided. The rust type system
 //! is then smart enough to accept the correct message type for each custom endpoint.
 //!
@@ -93,7 +93,7 @@
 //!                 .base_execute(deps, env, info, exec_msg)
 //!                 .map_err(From::from),
 //!             // handle the other messages with a custom handler set by the developer
-//!             // by passing `self` to the handlers we expose all the features and APIs that the base contract provides through the SDK.
+//!             // by passing `self` to the handlers we expose all the features and Adapters that the base contract provides through the SDK.
 //!             ExecuteMsg::App(request) => self.execute_handler()?(deps, env, info, self, request),
 //!             ExecuteMsg::IbcCallback(msg) => self.ibc_callback(deps, env, info, msg),
 //!             ExecuteMsg::Receive(msg) => self.receive(deps, env, info, msg),

--- a/packages/abstract-sdk/src/base/features/abstract_name_service.rs
+++ b/packages/abstract-sdk/src/base/features/abstract_name_service.rs
@@ -2,7 +2,7 @@ use crate::{ans_resolve::Resolve, AbstractSdkResult};
 use abstract_core::objects::ans_host::AnsHost;
 use cosmwasm_std::Deps;
 
-/// Trait that enables APIs that depend on the Abstract Name Service.
+/// Trait that enables Adapters that depend on the Abstract Name Service.
 pub trait AbstractNameService: Sized {
     fn ans_host(&self, deps: Deps) -> AbstractSdkResult<AnsHost>;
 

--- a/packages/abstract-sdk/src/base/mod.rs
+++ b/packages/abstract-sdk/src/base/mod.rs
@@ -1,6 +1,6 @@
 //! Base of an Abstract Module and its features.  
 //!
-//! Is used by the `abstract-api`, `abstract-ibc-host` and `abstract-app` crates.
+//! Is used by the `abstract-adapter`, `abstract-ibc-host` and `abstract-app` crates.
 
 mod contract_base;
 mod endpoints;

--- a/packages/abstract-sdk/src/lib.rs
+++ b/packages/abstract-sdk/src/lib.rs
@@ -23,7 +23,7 @@ pub mod feature_objects;
 pub use error::{AbstractSdkError, EndpointError};
 
 pub use crate::apis::{
-    api::*, app::*, bank::*, execution::*, ibc::*, modules::*, respond::*, vault::*, verify::*,
+    adapter::*, app::*, bank::*, execution::*, ibc::*, modules::*, respond::*, vault::*, verify::*,
     version_registry::*,
 };
 
@@ -31,7 +31,7 @@ pub mod features {
     //! # Feature traits
     //! Features are traits that are implemented on the base layer of a module. Implementing a feature unlocks the API objects that are dependent on it.  
     //!
-    //! You can easily create and provide your own API for other smart-contract developers by using these features as trait bounds.
+    //! You can easily create and provide your own Adapter for other smart-contract developers by using these features as trait bounds.
     pub use crate::base::features::*;
 }
 

--- a/packages/abstract-sdk/src/mock_module.rs
+++ b/packages/abstract-sdk/src/mock_module.rs
@@ -56,9 +56,9 @@ pub struct MockModuleExecuteMsg {}
 #[cosmwasm_schema::cw_serde]
 pub struct MockModuleQueryMsg {}
 
-impl abstract_core::api::ApiExecuteMsg for MockModuleExecuteMsg {}
+impl abstract_core::adapter::AdapterExecuteMsg for MockModuleExecuteMsg {}
 
-impl abstract_core::api::ApiQueryMsg for MockModuleQueryMsg {}
+impl abstract_core::adapter::AdapterQueryMsg for MockModuleQueryMsg {}
 
 impl abstract_core::app::AppExecuteMsg for MockModuleExecuteMsg {}
 

--- a/publish/publish.sh
+++ b/publish/publish.sh
@@ -18,7 +18,7 @@ BASE_PACKAGES="abstract-ica abstract-macros"
 UTILS_PACKAGES="abstract-core abstract-testing abstract-sdk"
 CORE_CONTRACTS="proxy manager"
 NATIVE_CONTRACTS="ans-host account-factory module-factory version-control"
-ALL_PACKAGES="abstract-boot abstract-api abstract-app abstract-ibc-host"
+ALL_PACKAGES="abstract-boot abstract-adapter abstract-app abstract-ibc-host"
 
  for pack in $BASE_PACKAGES; do
    (

--- a/scripts/src/bin/full_deploy.rs
+++ b/scripts/src/bin/full_deploy.rs
@@ -40,7 +40,7 @@ fn full_deploy(_network: NetworkInfo) -> anyhow::Result<()> {
             monarch: sender.to_string(),
         })?;
 
-    // let _dex = DexApi::new("dex", chain);
+    // let _dex = DexAdapter::new("dex", chain);
 
     // deployment.deploy_modules()?;
 

--- a/scripts/src/bin/remove_version.rs
+++ b/scripts/src/bin/remove_version.rs
@@ -11,7 +11,7 @@ const NETWORK: NetworkInfo = networks::UNI_6;
 
 const _MODULE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-pub fn deploy_api() -> anyhow::Result<()> {
+pub fn deploy_adapter() -> anyhow::Result<()> {
     let rt = Arc::new(tokio::runtime::Runtime::new().unwrap());
 
     let daemon_options = DaemonOptionsBuilder::default().network(NETWORK).build()?;
@@ -73,7 +73,7 @@ fn main() {
 
     let _args = Arguments::parse();
 
-    if let Err(ref err) = deploy_api() {
+    if let Err(ref err) = deploy_adapter() {
         log::error!("{}", err);
         err.chain()
             .skip(1)


### PR DESCRIPTION
This change makes the name of our modules more clear. `adapter` more clearly encapsulates the functionality of these non-migrateable contracts.