### PR TITLE
Block claiming of abstract namespace or admin account

### DIFF
--- a/contracts/account/manager/tests/common/mod.rs
+++ b/contracts/account/manager/tests/common/mod.rs
@@ -1,7 +1,8 @@
 #![allow(unused)]
 pub mod mock_modules;
 
-pub const OWNER: &str = "owner";
+pub use abstract_testing::addresses::TEST_OWNER;
+pub const OWNER: &str = TEST_OWNER;
 pub const TEST_COIN: &str = "ucoin";
 
 use ::abstract_manager::contract::CONTRACT_VERSION;

--- a/contracts/account/manager/tests/proxy.rs
+++ b/contracts/account/manager/tests/proxy.rs
@@ -2,7 +2,7 @@ mod common;
 use abstract_boot::*;
 use abstract_core::{manager::ManagerModuleInfo, PROXY};
 use abstract_manager::contract::CONTRACT_VERSION;
-use abstract_testing::prelude::TEST_VERSION;
+use abstract_testing::prelude::{TEST_ACCOUNT_ID, TEST_VERSION};
 use boot_core::{instantiate_default_mock_env, ContractInstance, Deploy};
 use common::{create_default_account, AResult, TEST_COIN};
 use cosmwasm_std::{Addr, Coin, CosmosMsg};
@@ -32,7 +32,7 @@ fn instantiate() -> AResult {
     assert_that!(account.manager.config()?).is_equal_to(abstract_core::manager::ConfigResponse {
         version_control_address: deployment.version_control.address()?,
         module_factory_address: deployment.module_factory.address()?,
-        account_id: 0u32.into(),
+        account_id: TEST_ACCOUNT_ID.into(),
         is_suspended: false,
     });
     Ok(())

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -9,7 +9,7 @@ use abstract_core::{
 };
 
 use abstract_manager::error::ManagerError;
-use abstract_testing::addresses::TEST_NAMESPACE;
+use abstract_testing::addresses::{TEST_ACCOUNT_ID, TEST_NAMESPACE};
 use abstract_testing::prelude::TEST_VERSION;
 use boot_core::{instantiate_default_mock_env, Addr, ContractInstance, Deploy, Empty, Mock};
 use common::mock_modules::*;
@@ -46,7 +46,7 @@ fn install_app_successful() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // dependency for mock_adapter1 not met
@@ -85,7 +85,7 @@ fn install_app_versions_not_met() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // install adapter 2
@@ -112,7 +112,7 @@ fn upgrade_app() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // install adapter 1
@@ -282,7 +282,7 @@ fn uninstall_modules() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
@@ -317,7 +317,7 @@ fn update_adapter_with_authorized_addrs() -> AResult {
     let AbstractAccount { manager, proxy } = &account;
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // install adapter 1
@@ -367,7 +367,7 @@ fn upgrade_manager_last() -> AResult {
 
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // install adapter 1
@@ -429,7 +429,7 @@ fn no_duplicate_migrations() -> AResult {
 
     abstr
         .version_control
-        .claim_namespaces(0, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // Install adapter 1

--- a/contracts/account/proxy/src/contract.rs
+++ b/contracts/account/proxy/src/contract.rs
@@ -6,7 +6,7 @@ use abstract_core::objects::oracle::Oracle;
 use abstract_macros::abstract_response;
 use abstract_sdk::{
     core::{
-        objects::core::ACCOUNT_ID,
+        objects::account_id::ACCOUNT_ID,
         proxy::{
             state::{State, ADMIN, ANS_HOST, STATE},
             AssetConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,

--- a/contracts/native/account-factory/src/commands.rs
+++ b/contracts/native/account-factory/src/commands.rs
@@ -5,7 +5,6 @@ use cosmwasm_std::{
 };
 use protobuf::Message;
 
-use abstract_sdk::core::{MANAGER, PROXY};
 use abstract_sdk::{
     core::{
         manager::{InstantiateMsg as ManagerInstantiateMsg, InternalConfigAction},
@@ -17,7 +16,7 @@ use abstract_sdk::{
         version_control::{
             AccountBase, ExecuteMsg as VCExecuteMsg, ModulesResponse, QueryMsg as VCQuery,
         },
-        AbstractResult,
+        AbstractResult, MANAGER, PROXY,
     },
     cw_helpers::cosmwasm_std::wasm_smart_query,
 };
@@ -76,7 +75,7 @@ pub fn execute_create_account(
     } else {
         Err(AccountFactoryError::WrongModuleKind(
             module.info.to_string(),
-            "core".to_string(),
+            "account_base".to_string(),
         ))
     }
 }

--- a/contracts/native/account-factory/src/contract.rs
+++ b/contracts/native/account-factory/src/contract.rs
@@ -65,7 +65,7 @@ pub fn execute(
             description,
         } => {
             let gov_details = governance.verify(deps.api)?;
-            commands::execute_create_account(deps, env, gov_details, name, description, link)
+            commands::execute_create_account(deps, env, info, gov_details, name, description, link)
         }
         ExecuteMsg::UpdateOwnership(action) => {
             execute_update_ownership!(AccountFactoryResponse, deps, env, info, action)

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -658,13 +658,13 @@ mod test {
             // Attempt to claim the abstract namespace with account 1
             let claim_abstract_msg = ExecuteMsg::ClaimNamespaces {
                 account_id: 1,
-                namespaces: vec![Namespace::from(ABSTRACT_NAMESPACE).to_string()],
+                namespaces: vec![Namespace::try_from(ABSTRACT_NAMESPACE)?.to_string()],
             };
             let res = execute_as(deps.as_mut(), TEST_OWNER, claim_abstract_msg);
             assert_that!(&res)
                 .is_err()
                 .is_equal_to(VCError::NamespaceOccupied {
-                    namespace: Namespace::from("abstract").to_string(),
+                    namespace: Namespace::try_from("abstract")?.to_string(),
                     id: ABSTRACT_ACCOUNT_ID,
                 });
             Ok(())

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -1,10 +1,12 @@
 use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, StdResult};
 use cw_semver::Version;
 
-use abstract_core::objects::module_version::assert_cw_contract_upgrade;
-use abstract_core::version_control::Config;
 use abstract_macros::abstract_response;
 use abstract_sdk::core::{
+    objects::{
+        module_version::assert_cw_contract_upgrade, namespace::Namespace, ABSTRACT_ACCOUNT_ID,
+    },
+    version_control::{namespaces_info, Config},
     version_control::{
         state::{CONFIG, FACTORY},
         ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
@@ -17,14 +19,14 @@ use crate::commands::*;
 use crate::error::VCError;
 use crate::queries;
 
+pub(crate) use abstract_core::objects::namespace::ABSTRACT_NAMESPACE;
+
 const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type VCResult<T = Response> = Result<T, VCError>;
 
 #[abstract_response(VERSION_CONTROL)]
 pub struct VcResponse;
-
-pub const ABSTRACT_NAMESPACE: &str = "abstract";
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn migrate(deps: DepsMut, _env: Env, _msg: MigrateMsg) -> VCResult {
@@ -41,19 +43,26 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
 
     let InstantiateMsg {
         is_testnet,
-        namespaces_limit,
+        namespace_limit,
     } = msg;
 
     CONFIG.save(
         deps.storage,
         &Config {
             is_testnet,
-            namespaces_limit,
+            namespace_limit,
         },
     )?;
 
     // Set up the admin as the creator of the contract
     cw_ownable::initialize_owner(deps.storage, deps.api, Some(info.sender.as_str()))?;
+
+    // Save the abstract namespace to the Abstract admin account
+    namespaces_info().save(
+        deps.storage,
+        &Namespace::new(ABSTRACT_NAMESPACE),
+        &ABSTRACT_ACCOUNT_ID,
+    )?;
 
     FACTORY.set(deps, None)?;
 
@@ -118,9 +127,26 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> StdResult<Binary> {
 mod tests {
     use super::*;
     use crate::contract;
-    use crate::test_common::*;
+    use crate::testing::*;
+    use abstract_core::objects::ABSTRACT_ACCOUNT_ID;
     use cosmwasm_std::testing::*;
     use speculoos::prelude::*;
+
+    mod instantiate {
+        use super::*;
+
+        #[test]
+        fn sets_abstract_namespace() -> VCResult<()> {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut())?;
+
+            let account_id = namespaces_info()
+                .load(deps.as_ref().storage, &Namespace::from(ABSTRACT_NAMESPACE))?;
+            assert_that!(account_id).is_equal_to(ABSTRACT_ACCOUNT_ID);
+
+            Ok(())
+        }
+    }
 
     mod migrate {
         use super::*;

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -5,10 +5,8 @@ use abstract_core::objects::namespace::Namespace;
 use abstract_core::version_control::Config;
 use abstract_macros::abstract_response;
 use abstract_sdk::core::{
-    objects::{
-        module_version::assert_cw_contract_upgrade, ABSTRACT_ACCOUNT_ID,
-    },
-    version_control::{namespaces_info},
+    objects::{module_version::assert_cw_contract_upgrade, ABSTRACT_ACCOUNT_ID},
+    version_control::namespaces_info,
     version_control::{
         state::{CONFIG, FACTORY},
         ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
@@ -158,8 +156,10 @@ mod tests {
             let mut deps = mock_dependencies();
             mock_init(deps.as_mut())?;
 
-            let account_id = namespaces_info()
-                .load(deps.as_ref().storage, &Namespace::try_from(ABSTRACT_NAMESPACE)?)?;
+            let account_id = namespaces_info().load(
+                deps.as_ref().storage,
+                &Namespace::try_from(ABSTRACT_NAMESPACE)?,
+            )?;
             assert_that!(account_id).is_equal_to(ABSTRACT_ACCOUNT_ID);
 
             Ok(())

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -1,15 +1,14 @@
 use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use cw_semver::Version;
 
-use abstract_core::objects::module_version::assert_cw_contract_upgrade;
 use abstract_core::objects::namespace::Namespace;
 use abstract_core::version_control::Config;
 use abstract_macros::abstract_response;
 use abstract_sdk::core::{
     objects::{
-        module_version::assert_cw_contract_upgrade, namespace::Namespace, ABSTRACT_ACCOUNT_ID,
+        module_version::assert_cw_contract_upgrade, ABSTRACT_ACCOUNT_ID,
     },
-    version_control::{namespaces_info, Config},
+    version_control::{namespaces_info},
     version_control::{
         state::{CONFIG, FACTORY},
         ConfigResponse, ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg,
@@ -63,7 +62,7 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
     // Save the abstract namespace to the Abstract admin account
     namespaces_info().save(
         deps.storage,
-        &Namespace::new(ABSTRACT_NAMESPACE),
+        &Namespace::new(ABSTRACT_NAMESPACE)?,
         &ABSTRACT_ACCOUNT_ID,
     )?;
 
@@ -160,7 +159,7 @@ mod tests {
             mock_init(deps.as_mut())?;
 
             let account_id = namespaces_info()
-                .load(deps.as_ref().storage, &Namespace::from(ABSTRACT_NAMESPACE))?;
+                .load(deps.as_ref().storage, &Namespace::try_from(ABSTRACT_NAMESPACE)?)?;
             assert_that!(account_id).is_equal_to(ABSTRACT_ACCOUNT_ID);
 
             Ok(())

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -88,7 +88,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
             account_base: base,
         } => add_account(deps, info, account_id, base),
         ExecuteMsg::UpdateNamespaceLimit { new_limit } => {
-            update_namespaces_limit(deps, info, new_limit)
+            update_namespace_limit(deps, info, new_limit)
         }
         ExecuteMsg::SetFactory { new_factory } => set_factory(deps, info, new_factory),
         ExecuteMsg::UpdateOwnership(action) => {

--- a/contracts/native/version-control/src/error.rs
+++ b/contracts/native/version-control/src/error.rs
@@ -45,14 +45,14 @@ pub enum VCError {
     #[error("Account with ID {} has no owner", account_id)]
     NoAccountOwner { account_id: AccountId },
 
-    #[error("Namespace {} is already occupied by {}", namespace, id)]
+    #[error("Namespace {} is already occupied by account {}", namespace, id)]
     NamespaceOccupied { namespace: String, id: AccountId },
 
     #[error("Exceeds namespace limit: {}, current: {}", limit, current)]
     ExceedsNamespaceLimit { limit: usize, current: usize },
 
     #[error(
-        "Decrease namespace limit not allowed: {}, current: {}",
+        "Decreasing namespace limit is not allowed: {}, current: {}",
         limit,
         current
     )]

--- a/contracts/native/version-control/src/lib.rs
+++ b/contracts/native/version-control/src/lib.rs
@@ -4,7 +4,7 @@ pub mod error;
 pub mod queries;
 
 #[cfg(test)]
-mod test_common {
+mod testing {
     use crate::contract;
     use crate::error::VCError;
     use abstract_core::version_control;
@@ -22,7 +22,7 @@ mod test_common {
             info,
             version_control::InstantiateMsg {
                 is_testnet: true,
-                namespaces_limit: 10,
+                namespace_limit: 10,
             },
         )
     }

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -308,7 +308,7 @@ mod test {
             info,
             InstantiateMsg {
                 is_testnet: true,
-                namespaces_limit: 10,
+                namespace_limit: 10,
             },
         )?;
         execute_as_admin(

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -262,7 +262,7 @@ mod test {
     const TEST_ADMIN: &str = "testadmin";
 
     const TEST_OTHER: &str = "testother";
-    const TEST_OTHER_ACCOUNT_ID: u32 = 1;
+    const TEST_OTHER_ACCOUNT_ID: u32 = 2;
     const TEST_OTHER_PROXY_ADDR: &str = "proxy1";
     const TEST_OTHER_MANAGER_ADDR: &str = "manager1";
 
@@ -1004,7 +1004,7 @@ mod test {
             assert_that!(res).is_ok().map(|res| {
                 let NamespaceListResponse { namespaces: resp } = from_binary(res).unwrap();
                 println!("{:?}", resp);
-                assert_that!(resp).has_length(5);
+                assert_that!(resp).has_length(6);
                 res
             });
 

--- a/packages/abstract-boot/src/deployment.rs
+++ b/packages/abstract-boot/src/deployment.rs
@@ -165,7 +165,7 @@ impl<Chain: CwEnv> Abstract<Chain> {
         self.version_control.instantiate(
             &abstract_core::version_control::InstantiateMsg {
                 is_testnet: true,
-                namespaces_limit: 1,
+                namespace_limit: 1,
             },
             Some(sender),
             None,

--- a/packages/abstract-boot/src/deployment.rs
+++ b/packages/abstract-boot/src/deployment.rs
@@ -13,6 +13,7 @@ pub struct Abstract<Chain: CwEnv> {
     pub account: AbstractAccount<Chain>,
 }
 
+use abstract_core::objects::gov_type::GovernanceDetails;
 use abstract_core::{ACCOUNT_FACTORY, ANS_HOST, MANAGER, MODULE_FACTORY, PROXY, VERSION_CONTROL};
 #[cfg(feature = "integration")]
 use boot_core::ContractWrapper;
@@ -131,6 +132,14 @@ impl<Chain: CwEnv> boot_core::Deploy<Chain> for Abstract<Chain> {
         deployment
             .version_control
             .register_natives(deployment.contracts(), &version)?;
+
+        // Create the first abstract account in integration environments
+        #[cfg(feature = "integration")]
+        deployment
+            .account_factory
+            .create_default_account(GovernanceDetails::Monarchy {
+                monarch: chain.sender().to_string(),
+            })?;
         Ok(deployment)
     }
 

--- a/packages/abstract-core/src/core/manager.rs
+++ b/packages/abstract-core/src/core/manager.rs
@@ -17,8 +17,8 @@
 pub mod state {
     use std::collections::HashSet;
 
+    pub use crate::objects::account_id::ACCOUNT_ID;
     use crate::objects::common_namespace::OWNERSHIP_STORAGE_KEY;
-    pub use crate::objects::core::ACCOUNT_ID;
     use crate::objects::{gov_type::GovernanceDetails, module::ModuleId};
     use cosmwasm_std::{Addr, Api};
     use cw_address_like::AddressLike;
@@ -91,7 +91,7 @@ pub mod state {
 use self::state::AccountInfo;
 use crate::manager::state::SuspensionStatus;
 use crate::objects::{
-    core::AccountId,
+    account_id::AccountId,
     gov_type::GovernanceDetails,
     module::{Module, ModuleInfo},
 };

--- a/packages/abstract-core/src/core/proxy.rs
+++ b/packages/abstract-core/src/core/proxy.rs
@@ -14,7 +14,7 @@
 use crate::{
     ibc_client::ExecuteMsg as IbcClientMsg,
     objects::{
-        core::AccountId,
+        account_id::AccountId,
         oracle::{AccountValue, Complexity},
         price_source::{PriceSource, UncheckedPriceSource},
         AssetEntry,
@@ -25,7 +25,7 @@ use cosmwasm_std::{CosmosMsg, Empty, Uint128};
 use cw_asset::{Asset, AssetInfo};
 
 pub mod state {
-    pub use crate::objects::core::ACCOUNT_ID;
+    pub use crate::objects::account_id::ACCOUNT_ID;
     use cw_controllers::Admin;
 
     use cosmwasm_std::Addr;

--- a/packages/abstract-core/src/ibc_host.rs
+++ b/packages/abstract-core/src/ibc_host.rs
@@ -13,7 +13,7 @@ use crate::{
         MigrateMsg as MiddlewareMigrateMsg, QueryMsg as MiddlewareQueryMsg,
     },
     ibc_client::CallbackInfo,
-    objects::core::AccountId,
+    objects::account_id::AccountId,
 };
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{Addr, Binary, CosmosMsg, Empty, QueryRequest};

--- a/packages/abstract-core/src/native/account_factory.rs
+++ b/packages/abstract-core/src/native/account_factory.rs
@@ -12,7 +12,7 @@ pub mod state {
     use cw_storage_plus::Item;
     use serde::{Deserialize, Serialize};
 
-    use crate::objects::core::AccountId;
+    use crate::objects::account_id::AccountId;
 
     /// Account Factory configuration
     #[cosmwasm_schema::cw_serde]
@@ -36,7 +36,7 @@ pub mod state {
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::Addr;
 
-use crate::objects::{core::AccountId, gov_type::GovernanceDetails};
+use crate::objects::{account_id::AccountId, gov_type::GovernanceDetails};
 
 /// Msg used on instantiation
 #[cosmwasm_schema::cw_serde]

--- a/packages/abstract-core/src/native/ibc_client.rs
+++ b/packages/abstract-core/src/native/ibc_client.rs
@@ -1,5 +1,5 @@
 use self::state::AccountData;
-use crate::{abstract_ica::StdAck, ibc_host::HostAction, objects::core::AccountId};
+use crate::{abstract_ica::StdAck, ibc_host::HostAction, objects::account_id::AccountId};
 use abstract_ica::IbcResponseMsg;
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::{from_slice, Binary, Coin, CosmosMsg, StdResult, Timestamp};
@@ -8,7 +8,7 @@ pub mod state {
 
     use super::LatestQueryResponse;
     use crate::{
-        objects::{ans_host::AnsHost, common_namespace::ADMIN_NAMESPACE, core::AccountId},
+        objects::{account_id::AccountId, ans_host::AnsHost, common_namespace::ADMIN_NAMESPACE},
         ANS_HOST as ANS_HOST_KEY,
     };
     use cosmwasm_std::{Addr, Coin, Timestamp};
@@ -265,7 +265,7 @@ mod tests {
         let callback_id = "15".to_string();
         let callback_info = CallbackInfo {
             id: callback_id,
-            receiver: receiver,
+            receiver,
         };
         let ack_data = &to_binary(&StdAck::Result(to_binary(&true).unwrap())).unwrap();
 

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -14,7 +14,7 @@ pub type ModuleMapEntry = (ModuleInfo, ModuleReference);
 #[cosmwasm_schema::cw_serde]
 pub struct Config {
     pub is_testnet: bool,
-    pub namespaces_limit: u32,
+    pub namespace_limit: u32,
 }
 
 pub mod state {
@@ -22,7 +22,7 @@ pub mod state {
     use cw_storage_plus::{Item, Map};
 
     use crate::objects::{
-        common_namespace::ADMIN_NAMESPACE, core::AccountId, module::ModuleInfo,
+        account_id::AccountId, common_namespace::ADMIN_NAMESPACE, module::ModuleInfo,
         module_reference::ModuleReference,
     };
 
@@ -64,7 +64,7 @@ pub fn namespaces_info<'a>() -> IndexedMap<'a, &'a Namespace, AccountId, Namespa
 }
 
 use crate::objects::{
-    core::AccountId,
+    account_id::AccountId,
     module::{Module, ModuleInfo, ModuleStatus},
     module_reference::ModuleReference,
     namespace::Namespace,
@@ -84,7 +84,7 @@ pub struct AccountBase {
 #[cosmwasm_schema::cw_serde]
 pub struct InstantiateMsg {
     pub is_testnet: bool,
-    pub namespaces_limit: u32,
+    pub namespace_limit: u32,
 }
 
 /// Version Control Execute Msg

--- a/packages/abstract-core/src/objects/account_id.rs
+++ b/packages/abstract-core/src/objects/account_id.rs
@@ -2,5 +2,8 @@ use cw_storage_plus::Item;
 
 pub type AccountId = u32;
 
+/// The Account id of Abstract's admin
+pub const ABSTRACT_ACCOUNT_ID: AccountId = 0;
+
 /// Account Id storage key
 pub const ACCOUNT_ID: Item<AccountId> = Item::new("\u{0}{10}account_id");

--- a/packages/abstract-core/src/objects/mod.rs
+++ b/packages/abstract-core/src/objects/mod.rs
@@ -15,7 +15,7 @@ pub mod pool;
 
 pub use pool::*;
 
-pub mod core;
+pub mod account_id;
 pub mod dependency;
 pub mod deposit_info;
 pub mod deposit_manager;
@@ -29,7 +29,7 @@ pub mod paged_map;
 pub mod price_source;
 pub mod time_weighted_average;
 
-pub use self::core::AccountId;
+pub use account_id::{AccountId, ABSTRACT_ACCOUNT_ID};
 pub use ans_asset::AnsAsset;
 pub use asset_entry::AssetEntry;
 pub use channel_entry::{ChannelEntry, UncheckedChannelEntry};

--- a/packages/abstract-core/src/objects/namespace.rs
+++ b/packages/abstract-core/src/objects/namespace.rs
@@ -8,6 +8,8 @@ use crate::AbstractResult;
 
 use super::module::validate_name;
 
+pub const ABSTRACT_NAMESPACE: &str = "abstract";
+
 /// Represents an Abstract namespace for modules
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Namespace(String);

--- a/packages/abstract-core/src/objects/paged_map.rs
+++ b/packages/abstract-core/src/objects/paged_map.rs
@@ -264,7 +264,7 @@ mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
 
-    use crate::objects::core::AccountId;
+    use crate::objects::account_id::AccountId;
     use cosmwasm_std::testing::{mock_dependencies, MockStorage};
 
     #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]

--- a/packages/abstract-sdk/src/apis/verify.rs
+++ b/packages/abstract-sdk/src/apis/verify.rs
@@ -111,9 +111,9 @@ mod test {
                 // Setup the addresses as if the Account was registered
                 .account("not_manager", "not_proxy", TEST_ACCOUNT_ID)
                 // update the proxy to be proxy of a different Account
-                .account(TEST_MANAGER, TEST_PROXY, 1)
+                .account(TEST_MANAGER, TEST_PROXY, 2)
                 .builder()
-                .with_contract_item("not_proxy", ACCOUNT_ID, &1)
+                .with_contract_item("not_proxy", ACCOUNT_ID, &2)
                 .build();
 
             let binding = MockBinding;
@@ -146,7 +146,10 @@ mod test {
             assert_that!(res)
                 .is_err()
                 .matches(|e| matches!(e, AbstractSdkError::UnknownAccountId { .. }))
-                .matches(|e| e.to_string().contains("Unknown Account id 0"));
+                .matches(|e| {
+                    e.to_string()
+                        .contains(format!("Unknown Account id {}", TEST_ACCOUNT_ID).as_str())
+                });
         }
 
         #[test]

--- a/packages/abstract-testing/src/abstract_mock_querier.rs
+++ b/packages/abstract-testing/src/abstract_mock_querier.rs
@@ -2,7 +2,7 @@ use crate::{addresses::*, mock_ans::MockAnsHost, MockQuerierBuilder};
 use abstract_core::objects::common_namespace::OWNERSHIP_STORAGE_KEY;
 use abstract_core::{
     ans_host::state::ASSET_ADDRESSES,
-    objects::{common_namespace::ADMIN_NAMESPACE, core::ACCOUNT_ID, AssetEntry},
+    objects::{account_id::ACCOUNT_ID, common_namespace::ADMIN_NAMESPACE, AssetEntry},
     version_control::{state::ACCOUNT_ADDRESSES, AccountBase},
 };
 use cosmwasm_std::{testing::MockQuerier, Addr};

--- a/packages/abstract-testing/src/lib.rs
+++ b/packages/abstract-testing/src/lib.rs
@@ -20,7 +20,7 @@ pub mod addresses {
 
     pub const TEST_CREATOR: &str = "creator";
     pub const TEST_ADMIN: &str = "admin";
-    pub const TEST_ACCOUNT_ID: AccountId = 0;
+    pub const TEST_ACCOUNT_ID: AccountId = 1;
     pub const TEST_VERSION: &str = "1.0.0";
     pub const TEST_PROXY: &str = "proxy_address";
     pub const TEST_MANAGER: &str = "manager_address";


### PR DESCRIPTION
This change sets the `abstract` namespace to be owned by account 0, which is the Abstract account. To prevent outsiders from claiming the Abstract admin account, we also restrict the account 0 creator to the admin of the factory (the deployer). 