### PR TITLE
Use Namespace type in ModuleInfo

### DIFF
--- a/contracts/native/ibc-client/src/ibc.rs
+++ b/contracts/native/ibc-client/src/ibc.rs
@@ -190,7 +190,7 @@ fn acknowledge_query(
 ) -> Result<IbcBasicResponse, IbcClientError> {
     let msg: StdAck = from_slice(&ack.acknowledgement.data)?;
     let res = IbcBasicResponse::new().add_attribute("action", "acknowledge_ibc_query");
-    // store IBC response for later querying from the smart contract??
+    // store IBC response for later querying from the smart contract?
     LATEST_QUERIES.save(
         deps.storage,
         (&channel_id, account_id),

--- a/contracts/native/version-control/src/error.rs
+++ b/contracts/native/version-control/src/error.rs
@@ -1,8 +1,10 @@
-use abstract_core::{objects::AccountId, AbstractError};
-use abstract_sdk::{core::objects::module::ModuleInfo, AbstractSdkError};
 use cosmwasm_std::{Addr, StdError};
 use cw_controllers::AdminError;
 use thiserror::Error;
+
+use abstract_core::objects::namespace::Namespace;
+use abstract_core::{objects::AccountId, AbstractError};
+use abstract_sdk::{core::objects::module::ModuleInfo, AbstractSdkError};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum VCError {
@@ -37,7 +39,7 @@ pub enum VCError {
     UnknownAccountId { id: AccountId },
 
     #[error("Namespace {} is not in version control register", namespace)]
-    UnknownNamespace { namespace: String },
+    UnknownNamespace { namespace: Namespace },
 
     #[error("Account owner mismatch sender: {}, owner: {}", sender, owner)]
     AccountOwnerMismatch { sender: Addr, owner: Addr },

--- a/packages/abstract-adapter/src/endpoints/execute.rs
+++ b/packages/abstract-adapter/src/endpoints/execute.rs
@@ -202,7 +202,7 @@ impl<Error: ContractError, CustomInitMsg, CustomExecMsg, CustomQueryMsg, Receive
                     address: deauthorized,
                 });
             } else {
-                authorized_addrs.retain(|addr| addr != &deauthorized_addr);
+                authorized_addrs.retain(|addr| addr != deauthorized_addr);
             }
         }
 

--- a/packages/abstract-core/src/native/ibc_client.rs
+++ b/packages/abstract-core/src/native/ibc_client.rs
@@ -265,7 +265,7 @@ mod tests {
         let callback_id = "15".to_string();
         let callback_info = CallbackInfo {
             id: callback_id,
-            receiver: receiver,
+            receiver,
         };
         let ack_data = &to_binary(&StdAck::Result(to_binary(&true).unwrap())).unwrap();
 

--- a/packages/abstract-core/src/objects/module.rs
+++ b/packages/abstract-core/src/objects/module.rs
@@ -1,4 +1,5 @@
 use super::module_reference::ModuleReference;
+use crate::objects::namespace::Namespace;
 use crate::{error::AbstractError, AbstractResult};
 use cosmwasm_std::{to_binary, Binary, StdError, StdResult};
 use cw2::ContractVersion;
@@ -24,7 +25,7 @@ pub enum ModuleStatus {
 #[cosmwasm_schema::cw_serde]
 pub struct ModuleInfo {
     /// Namespace of the module
-    pub namespace: String,
+    pub namespace: Namespace,
     /// Name of the contract
     pub name: String,
     /// Version of the module
@@ -80,7 +81,7 @@ impl ModuleInfo {
             });
         }
         Ok(ModuleInfo {
-            namespace: split[0].to_lowercase(),
+            namespace: Namespace::try_from(split[0])?,
             name: split[1].to_lowercase(),
             version,
         })
@@ -90,7 +91,7 @@ impl ModuleInfo {
     }
 
     pub fn validate(&self) -> AbstractResult<()> {
-        validate_name(&self.namespace)?;
+        self.namespace.validate()?;
         validate_name(&self.name)?;
         self.version.validate().map_err(|e| {
             StdError::generic_err(format!("Invalid version for module {}: {}", self.id(), e))
@@ -121,13 +122,17 @@ impl ModuleInfo {
 }
 
 impl<'a> PrimaryKey<'a> for &ModuleInfo {
-    type Prefix = (String, String);
+    /// (namespace, name)
+    type Prefix = (Namespace, String);
 
-    type SubPrefix = String;
+    /// namespace
+    type SubPrefix = Namespace;
 
     /// Possibly change to ModuleVersion in future by implementing PrimaryKey
+    /// version
     type Suffix = String;
 
+    // (name, version)
     type SuperSuffix = (String, String);
 
     fn key(&self) -> Vec<cw_storage_plus::Key> {
@@ -175,7 +180,9 @@ impl KeyDeserialize for &ModuleInfo {
         let ver = name_ver.split_off(ver_len);
 
         Ok(ModuleInfo {
-            namespace: String::from_vec(prov_name_ver)?,
+            namespace: Namespace::try_from(String::from_vec(prov_name_ver)?).map_err(|e| {
+                StdError::generic_err(format!("Invalid namespace for module: {}", e))
+            })?,
             name: String::from_vec(name_ver)?,
             version: ModuleVersion::from_vec(ver)?,
         })
@@ -282,7 +289,7 @@ impl TryFrom<ContractVersion> for ModuleInfo {
             });
         }
         Ok(ModuleInfo {
-            namespace: split[0].to_lowercase(),
+            namespace: Namespace::try_from(split[0])?,
             name: split[1].to_lowercase(),
             version: ModuleVersion::Version(value.version),
         })
@@ -356,7 +363,7 @@ mod test {
 
         fn mock_key() -> ModuleInfo {
             ModuleInfo {
-                namespace: "abstract".to_string(),
+                namespace: Namespace::new("abstract").unwrap(),
                 name: "rocket-ship".to_string(),
                 version: ModuleVersion::Version("1.9.9".into()),
             }
@@ -365,22 +372,22 @@ mod test {
         fn mock_keys() -> (ModuleInfo, ModuleInfo, ModuleInfo, ModuleInfo) {
             (
                 ModuleInfo {
-                    namespace: "abstract".to_string(),
+                    namespace: Namespace::new("abstract").unwrap(),
                     name: "boat".to_string(),
                     version: ModuleVersion::Version("1.9.9".into()),
                 },
                 ModuleInfo {
-                    namespace: "abstract".to_string(),
+                    namespace: Namespace::new("abstract").unwrap(),
                     name: "rocket-ship".to_string(),
                     version: ModuleVersion::Version("1.0.0".into()),
                 },
                 ModuleInfo {
-                    namespace: "abstract".to_string(),
+                    namespace: Namespace::new("abstract").unwrap(),
                     name: "rocket-ship".to_string(),
                     version: ModuleVersion::Version("2.0.0".into()),
                 },
                 ModuleInfo {
-                    namespace: "astroport".to_string(),
+                    namespace: Namespace::new("astroport").unwrap(),
                     name: "liquidity-pool".to_string(),
                     version: ModuleVersion::Version("10.5.7".into()),
                 },
@@ -410,7 +417,7 @@ mod test {
         fn storage_key_with_overlapping_name_namespace() {
             let mut deps = mock_dependencies();
             let info1 = ModuleInfo {
-                namespace: "abstract".to_string(),
+                namespace: Namespace::new("abstract").unwrap(),
                 name: "ans".to_string(),
                 version: ModuleVersion::Version("1.9.9".into()),
             };
@@ -418,7 +425,7 @@ mod test {
             let _key1 = (&info1).joined_key();
 
             let info2 = ModuleInfo {
-                namespace: "abs".to_string(),
+                namespace: Namespace::new("abs").unwrap(),
                 name: "tractans".to_string(),
                 version: ModuleVersion::Version("1.9.9".into()),
             };
@@ -482,7 +489,7 @@ mod test {
             map.save(deps.as_mut().storage, &key4, &13).unwrap();
 
             let items = map
-                .sub_prefix("abstract".to_string())
+                .sub_prefix(Namespace::new("abstract").unwrap())
                 .range(deps.as_ref().storage, None, None, Order::Ascending)
                 .map(|item| item.unwrap())
                 .collect::<Vec<_>>();
@@ -500,7 +507,7 @@ mod test {
             );
 
             let items = map
-                .sub_prefix("astroport".to_string())
+                .sub_prefix(Namespace::new("astroport").unwrap())
                 .range(deps.as_ref().storage, None, None, Order::Ascending)
                 .map(|item| item.unwrap())
                 .collect::<Vec<_>>();
@@ -527,7 +534,10 @@ mod test {
             map.save(deps.as_mut().storage, &key4, &13).unwrap();
 
             let items = map
-                .prefix(("abstract".to_string(), "rocket-ship".to_string()))
+                .prefix((
+                    Namespace::new("abstract").unwrap(),
+                    "rocket-ship".to_string(),
+                ))
                 .range(deps.as_ref().storage, None, None, Order::Ascending)
                 .map(|item| item.unwrap())
                 .collect::<Vec<_>>();
@@ -545,7 +555,7 @@ mod test {
         #[test]
         fn validate_with_empty_name() {
             let info = ModuleInfo {
-                namespace: "abstract".to_string(),
+                namespace: Namespace::try_from("abstract").unwrap(),
                 name: "".to_string(),
                 version: ModuleVersion::Version("1.9.9".into()),
             };
@@ -558,7 +568,7 @@ mod test {
         #[test]
         fn validate_with_empty_namespace() {
             let info = ModuleInfo {
-                namespace: "".to_string(),
+                namespace: Namespace::unchecked(""),
                 name: "ans".to_string(),
                 version: ModuleVersion::Version("1.9.9".into()),
             };
@@ -576,7 +586,7 @@ mod test {
         #[case("ans-host&")]
         fn validate_fails_with_non_alphanumeric(#[case] name: &str) {
             let info = ModuleInfo {
-                namespace: "abstract".to_string(),
+                namespace: Namespace::try_from("abstract").unwrap(),
                 name: name.to_string(),
                 version: ModuleVersion::Version("1.9.9".into()),
             };
@@ -591,7 +601,7 @@ mod test {
         #[case("bad-")]
         fn validate_with_bad_versions(#[case] version: &str) {
             let info = ModuleInfo {
-                namespace: "abstract".to_string(),
+                namespace: Namespace::try_from("abstract").unwrap(),
                 name: "ans".to_string(),
                 version: ModuleVersion::Version(version.into()),
             };
@@ -605,7 +615,7 @@ mod test {
         fn id() {
             let info = ModuleInfo {
                 name: "name".to_string(),
-                namespace: "namespace".to_string(),
+                namespace: Namespace::try_from("namespace").unwrap(),
                 version: ModuleVersion::Version("1.0.0".into()),
             };
 
@@ -618,7 +628,7 @@ mod test {
         fn id_with_version() {
             let info = ModuleInfo {
                 name: "name".to_string(),
-                namespace: "namespace".to_string(),
+                namespace: Namespace::try_from("namespace").unwrap(),
                 version: ModuleVersion::Version("1.0.0".into()),
             };
 

--- a/packages/abstract-sdk/src/apis/verify.rs
+++ b/packages/abstract-sdk/src/apis/verify.rs
@@ -28,7 +28,7 @@ impl<'a, T: OsVerification> OsRegistry<'a, T> {
     pub fn assert_manager(&self, maybe_manager: &Addr) -> AbstractSdkResult<AccountBase> {
         let account_id = self.account_id(maybe_manager)?;
         let account_base = self.account_base(account_id)?;
-        if &account_base.manager != maybe_manager {
+        if account_base.manager != maybe_manager {
             Err(AbstractSdkError::NotManager(
                 maybe_manager.clone(),
                 account_id,

--- a/packages/abstract-sdk/src/apis/verify.rs
+++ b/packages/abstract-sdk/src/apis/verify.rs
@@ -42,7 +42,7 @@ impl<'a, T: OsVerification> OsRegistry<'a, T> {
     pub fn assert_proxy(&self, maybe_proxy: &Addr) -> AbstractSdkResult<AccountBase> {
         let account_id = self.account_id(maybe_proxy)?;
         let account_base = self.account_base(account_id)?;
-        if &account_base.proxy != maybe_proxy {
+        if account_base.proxy != maybe_proxy {
             Err(AbstractSdkError::NotProxy(maybe_proxy.clone(), account_id))
         } else {
             Ok(account_base)

--- a/scripts/src/bin/fix_names.rs
+++ b/scripts/src/bin/fix_names.rs
@@ -8,6 +8,7 @@ use boot_core::{
     *,
 };
 
+use abstract_core::objects::namespace::Namespace;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -31,7 +32,7 @@ pub fn fix_names() -> anyhow::Result<()> {
             name,
             namespace,
         } = info.clone();
-        if namespace == NAMESPACE && name.to_string().contains('_') {
+        if namespace == Namespace::unchecked(NAMESPACE) && name.to_string().contains('_') {
             deployment.version_control.remove_module(info)?;
             deployment.version_control.propose_modules(vec![(
                 ModuleInfo {

--- a/scripts/src/bin/fix_versions.rs
+++ b/scripts/src/bin/fix_versions.rs
@@ -8,6 +8,7 @@ use boot_core::{
     *,
 };
 
+use abstract_core::objects::namespace::Namespace;
 use std::sync::Arc;
 use tokio::runtime::Runtime;
 
@@ -40,7 +41,7 @@ pub fn fix_versions() -> anyhow::Result<()> {
             name,
             namespace,
         } = info.clone();
-        if version.to_string() == *WRONG_VERSION && namespace == *NAMESPACE {
+        if version.to_string() == *WRONG_VERSION && namespace == Namespace::unchecked(NAMESPACE) {
             deployment.version_control.remove_module(info)?;
             deployment.version_control.propose_modules(vec![(
                 ModuleInfo {

--- a/scripts/src/bin/remove_version.rs
+++ b/scripts/src/bin/remove_version.rs
@@ -30,7 +30,7 @@ pub fn deploy_adapter() -> anyhow::Result<()> {
     for version in old_versions {
         let res = version_control.remove_module(ModuleInfo {
             name: "autocompounder".to_string(),
-            namespace: "4t2".into(),
+            namespace: "4t2".try_into()?,
             version: ModuleVersion::from(version),
         });
 
@@ -40,7 +40,7 @@ pub fn deploy_adapter() -> anyhow::Result<()> {
 
         let res = version_control.remove_module(ModuleInfo {
             name: "cw_staking".to_string(),
-            namespace: "4t2".into(),
+            namespace: "4t2".try_into()?,
             version: ModuleVersion::from(version),
         });
 


### PR DESCRIPTION
This change uses the `Namespace` type in the `ModuleInfo`, which validates that the provided namespace is valid. That way, we know everywhere that a given namespace would be valid.