### PR TITLE
Add prelude mod to SDK

### DIFF
--- a/packages/abstract-sdk/src/lib.rs
+++ b/packages/abstract-sdk/src/lib.rs
@@ -1,10 +1,6 @@
 #![doc(html_logo_url = "https://raw.githubusercontent.com/AbstractSDK/assets/mainline/logo.svg")]
 #![doc = include_str ! ("../README.md")]
-#![doc(test(attr(
-    warn(unused),
-    deny(warnings),
-    allow(unused_extern_crates, unused),
-)))]
+#![doc(test(attr(warn(unused), deny(warnings), allow(unused_extern_crates, unused),)))]
 
 pub type AbstractSdkResult<T> = Result<T, crate::error::AbstractSdkError>;
 

--- a/packages/abstract-sdk/src/lib.rs
+++ b/packages/abstract-sdk/src/lib.rs
@@ -3,14 +3,12 @@
 #![doc(test(attr(
     warn(unused),
     deny(warnings),
-    // W/o this, we seem to get some bogus warning about `extern crate zbus`.
     allow(unused_extern_crates, unused),
 )))]
 
 pub type AbstractSdkResult<T> = Result<T, crate::error::AbstractSdkError>;
 
 pub extern crate abstract_core as core;
-extern crate abstract_macros as macros;
 
 mod ans_resolve;
 mod apis;
@@ -19,6 +17,7 @@ pub mod base;
 pub mod cw_helpers;
 mod error;
 pub mod feature_objects;
+pub mod prelude;
 
 pub use error::{AbstractSdkError, EndpointError};
 

--- a/packages/abstract-sdk/src/prelude.rs
+++ b/packages/abstract-sdk/src/prelude.rs
@@ -1,9 +1,9 @@
 //! # SDK Prelude
-//! 
+//!
 //! Re-exports all the API traits to make it easier to access them.
-//! 
+//!
 //! ## Usage
-//! 
+//!
 //! ```rust
 //! use abstract_sdk::prelude::*;
 //! ```

--- a/packages/abstract-sdk/src/prelude.rs
+++ b/packages/abstract-sdk/src/prelude.rs
@@ -1,0 +1,19 @@
+//! # SDK Prelude
+//! 
+//! Re-exports all the API traits to make it easier to access them.
+//! 
+//! ## Usage
+//! 
+//! ```rust
+//! use abstract_sdk::prelude::*;
+//! ```
+
+pub use crate::apis::{
+    adapter::*, app::*, bank::*, execution::*, ibc::*, modules::*, respond::*, vault::*, verify::*,
+    version_registry::*,
+};
+
+#[cfg(feature = "stargate")]
+pub use crate::apis::{distribution::*, grant::*};
+
+pub use crate::ans_resolve::Resolve;


### PR DESCRIPTION
Adds a prelude mod to the abstract-sdk that re-exports all the API traits. This prelude should be added to each handler file to more easily see all the available APIs on the app/adapter object.