### PR TITLE
Feature/wrap sdk messages

### DIFF
--- a/packages/abstract-sdk/Cargo.toml
+++ b/packages/abstract-sdk/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 # for quicker tests, cargo test --lib
 [features]
-default = []
+default = ["stargate"]
 stargate = ["dep:cosmos-sdk-proto", "dep:prost-types"]
 
 # Expose MockModule for testing with other Adapters

--- a/packages/abstract-sdk/README.md
+++ b/packages/abstract-sdk/README.md
@@ -34,6 +34,7 @@ The [`Bank`](https://docs.rs/abstract-sdk/latest/abstract_sdk/apis/bank) Adapter
 use abstract_sdk::{TransferInterface,AbstractSdkResult};
 use abstract_core::objects::AnsAsset;
 use cosmwasm_std::{Addr, CosmosMsg, Deps, StdResult, Uint128};
+use abstract_sdk::cw_helpers::cw_messages::{AbstractMessage, AbstractMessageMerge};
 
 // Trait to retrieve the Splitter object
 // Depends on the ability to transfer funds
@@ -71,7 +72,8 @@ impl<'a, T: SplitterInterface> Splitter<'a, T> {
                 // Construct the transfer message
                 bank.transfer(vec![&receives_each], receiver)
             })
-            .collect();
+            .collect::<AbstractSdkResult<Vec<_>>>()?
+            .merge();
 
         transfer_msgs
     }
@@ -105,7 +107,7 @@ The API can then be used by any contract that implements its required traits, in
 
   fn forward_deposit(deps: Deps, my_contract: MyContract, message_info: MessageInfo) -> AbstractSdkResult<CosmosMsg> {
       let send_deposit_to_vault_msg = my_contract.bank(deps).deposit_coins(message_info.funds)?;
-      Ok(send_deposit_to_vault_msg)
+      Ok(send_deposit_to_vault_msg.into())
   }
 ```
 

--- a/packages/abstract-sdk/src/apis/adapter.rs
+++ b/packages/abstract-sdk/src/apis/adapter.rs
@@ -1,8 +1,8 @@
 #![allow(dead_code)]
 
-use crate::{AbstractSdkResult, ModuleInterface};
+use crate::{AbstractSdkResult, ModuleInterface, cw_helpers::cw_messages::AbstractMessage};
 use abstract_core::{adapter::AdapterRequestMsg, objects::module::ModuleId};
-use cosmwasm_std::{wasm_execute, CosmosMsg, Deps, Empty};
+use cosmwasm_std::{wasm_execute, Deps, Empty};
 use serde::{de::DeserializeOwned, Serialize};
 
 /// Interact with other modules on the Account.
@@ -27,7 +27,7 @@ impl<'a, T: AdapterInterface> Adapter<'a, T> {
         &self,
         adapter_id: ModuleId,
         message: M,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let modules = self.base.modules(self.deps);
         modules.assert_module_dependency(adapter_id)?;
         let adapter_msg = abstract_core::adapter::ExecuteMsg::<_>::Module(AdapterRequestMsg::new(
@@ -113,11 +113,11 @@ mod tests {
 
             assert_that!(res)
                 .is_ok()
-                .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
+                .is_equal_to::<AbstractMessage>(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_MODULE_ADDRESS.into(),
                     msg: to_binary(&expected_msg).unwrap(),
                     funds: vec![],
-                }));
+                }).into());
         }
     }
 

--- a/packages/abstract-sdk/src/apis/app.rs
+++ b/packages/abstract-sdk/src/apis/app.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
-use crate::{AbstractSdkResult, ModuleInterface};
+use crate::{AbstractSdkResult, ModuleInterface, cw_helpers::cw_messages::AbstractMessage};
 use abstract_core::objects::module::ModuleId;
-use cosmwasm_std::{wasm_execute, CosmosMsg, Deps, Empty};
+use cosmwasm_std::{wasm_execute, Deps, Empty};
 use serde::{de::DeserializeOwned, Serialize};
 
 use abstract_core::app as msg;
@@ -27,7 +27,7 @@ impl<'a, T: AppInterface> App<'a, T> {
         &self,
         app_id: ModuleId,
         message: impl Into<msg::ExecuteMsg<M, Empty>>,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let modules = self.base.modules(self.deps);
         modules.assert_module_dependency(app_id)?;
         let app_msg: msg::ExecuteMsg<M, Empty> = message.into();
@@ -40,7 +40,7 @@ impl<'a, T: AppInterface> App<'a, T> {
         &self,
         app_id: ModuleId,
         message: msg::BaseExecuteMsg,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let app_msg: msg::ExecuteMsg<Empty, Empty> = message.into();
         let modules = self.base.modules(self.deps);
         let app_address = modules.module_address(app_id)?;
@@ -121,11 +121,11 @@ mod tests {
 
             assert_that!(res)
                 .is_ok()
-                .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
+                .is_equal_to::<AbstractMessage>(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_MODULE_ADDRESS.into(),
                     msg: to_binary(&expected_msg).unwrap(),
                     funds: vec![],
-                }));
+                }).into());
         }
     }
 
@@ -172,11 +172,11 @@ mod tests {
 
             assert_that!(res)
                 .is_ok()
-                .is_equal_to(CosmosMsg::Wasm(WasmMsg::Execute {
+                .is_equal_to::<AbstractMessage>(CosmosMsg::Wasm(WasmMsg::Execute {
                     contract_addr: TEST_MODULE_ADDRESS.into(),
                     msg: to_binary(&expected_msg).unwrap(),
                     funds: vec![],
-                }));
+                }).into());
         }
     }
 

--- a/packages/abstract-sdk/src/apis/bank.rs
+++ b/packages/abstract-sdk/src/apis/bank.rs
@@ -2,7 +2,7 @@
 //! The Bank object handles asset transfers to and from the Account.
 
 use crate::{ans_resolve::Resolve, features::AbstractNameService, AbstractSdkResult, Execution};
-use crate::cw_helpers::cw_messages::{AbstractMessage, ConvertToAbstractMessage};
+use crate::cw_helpers::cw_messages::{AbstractMessage};
 use core::objects::{AnsAsset, AssetEntry};
 use cosmwasm_std::{Addr, BankMsg, Coin, CosmosMsg, Deps};
 use cw_asset::Asset;
@@ -102,9 +102,8 @@ impl<'a, T: TransferInterface> Bank<'a, T> {
             .collect::<AbstractSdkResult<Vec<Asset>>>()?;
         transferable_funds
             .iter()
-            .map(|asset| asset.transfer_msg(recipient.clone()))
-            .collect::<Result<Vec<CosmosMsg>, _>>()
-            .into_abstract_messages()
+            .map(|asset| asset.transfer_msg(recipient.clone()).map(Into::into))
+            .collect::<Result<Vec<AbstractMessage>, _>>()
 
             .map_err(Into::into)
     }

--- a/packages/abstract-sdk/src/apis/distribution.rs
+++ b/packages/abstract-sdk/src/apis/distribution.rs
@@ -9,7 +9,7 @@ use cosmos_sdk_proto::{
 use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Deps};
 
 use crate::{AbstractSdkResult, Execution};
-
+use crate::cw_helpers::cw_messages::AbstractMessage;
 pub trait DistributionInterface: Execution {
     fn distribution<'a>(&'a self, deps: Deps<'a>) -> Distribution<Self> {
         Distribution { base: self, deps }
@@ -30,7 +30,7 @@ impl<'a, T: DistributionInterface> Distribution<'a, T> {
         &self,
         delegator: &Addr,
         withdraw: &Addr,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let msg = distribution::v1beta1::MsgSetWithdrawAddress {
             delegator_address: delegator.into(),
             withdraw_address: withdraw.into(),
@@ -50,7 +50,7 @@ impl<'a, T: DistributionInterface> Distribution<'a, T> {
         &self,
         validator: &Addr,
         delegator: &Addr,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let msg = distribution::v1beta1::MsgWithdrawDelegatorReward {
             validator_address: validator.into(),
             delegator_address: delegator.into(),
@@ -66,7 +66,7 @@ impl<'a, T: DistributionInterface> Distribution<'a, T> {
     }
 
     /// withdraws the full commission to the validator address.
-    pub fn withdraw_delegator_commission(&self, validator: &Addr) -> AbstractSdkResult<CosmosMsg> {
+    pub fn withdraw_delegator_commission(&self, validator: &Addr) -> AbstractSdkResult<AbstractMessage> {
         let msg = distribution::v1beta1::MsgWithdrawValidatorCommission {
             validator_address: validator.into(),
         }
@@ -85,7 +85,7 @@ impl<'a, T: DistributionInterface> Distribution<'a, T> {
         &self,
         amount: &[Coin],
         depositor: &Addr,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let msg = distribution::v1beta1::MsgFundCommunityPool {
             amount: amount
                 .iter()

--- a/packages/abstract-sdk/src/apis/grant.rs
+++ b/packages/abstract-sdk/src/apis/grant.rs
@@ -10,6 +10,7 @@ use cosmos_sdk_proto::{cosmos::base, cosmos::feegrant, traits::Message, Any};
 use cosmwasm_std::{to_binary, Addr, Coin, CosmosMsg, Deps, Timestamp};
 
 use crate::AbstractSdkResult;
+use crate::cw_helpers::cw_messages::AbstractMessage;
 
 pub trait GrantInterface: Execution {
     fn grant<'a>(&'a self, deps: Deps<'a>) -> Grant<Self> {
@@ -33,7 +34,7 @@ impl<'a, T: GrantInterface> Grant<'a, T> {
         granter: &Addr,
         grantee: &Addr,
         basic: BasicAllowance,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let msg = feegrant::v1beta1::MsgGrantAllowance {
             granter: granter.into(),
             grantee: grantee.into(),
@@ -57,7 +58,7 @@ impl<'a, T: GrantInterface> Grant<'a, T> {
         grantee: &Addr,
         basic: Option<BasicAllowance>,
         periodic: PeriodicAllowance,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let msg = feegrant::v1beta1::MsgGrantAllowance {
             granter: granter.into(),
             grantee: grantee.into(),
@@ -74,7 +75,7 @@ impl<'a, T: GrantInterface> Grant<'a, T> {
     }
 
     /// creates allowance only for BasicAllowance.
-    pub fn allow_basic(&self, basic: BasicAllowance) -> AbstractSdkResult<CosmosMsg> {
+    pub fn allow_basic(&self, basic: BasicAllowance) -> AbstractSdkResult<AbstractMessage> {
         let msg = feegrant::v1beta1::AllowedMsgAllowance {
             allowance: Some(build_any_basic(basic)),
             allowed_messages: vec!["BasicAllowance".to_owned()],
@@ -90,7 +91,7 @@ impl<'a, T: GrantInterface> Grant<'a, T> {
     }
 
     /// Creates allowance only for PeriodicAllowance.
-    pub fn allow_periodic(&self, periodic: PeriodicAllowance) -> AbstractSdkResult<CosmosMsg> {
+    pub fn allow_periodic(&self, periodic: PeriodicAllowance) -> AbstractSdkResult<AbstractMessage> {
         let msg = feegrant::v1beta1::AllowedMsgAllowance {
             allowance: Some(build_any_periodic(periodic, None)),
             allowed_messages: vec!["PeriodicAllowance".to_owned()],
@@ -110,7 +111,7 @@ impl<'a, T: GrantInterface> Grant<'a, T> {
         &self,
         basic: BasicAllowance,
         periodic: PeriodicAllowance,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         let msg = feegrant::v1beta1::AllowedMsgAllowance {
             allowance: Some(build_any_periodic(periodic, Some(basic))),
             allowed_messages: vec!["BasicAllowance".to_owned(), "PeriodicAllowance".to_owned()],
@@ -126,7 +127,7 @@ impl<'a, T: GrantInterface> Grant<'a, T> {
     }
 
     /// Removes any existing Allowance from Granter to Grantee.
-    pub fn revoke_all(&self, granter: &Addr, grantee: &Addr) -> AbstractSdkResult<CosmosMsg> {
+    pub fn revoke_all(&self, granter: &Addr, grantee: &Addr) -> AbstractSdkResult<AbstractMessage> {
         let msg = feegrant::v1beta1::MsgRevokeAllowance {
             granter: granter.into(),
             grantee: grantee.into(),

--- a/packages/abstract-sdk/src/apis/ibc.rs
+++ b/packages/abstract-sdk/src/apis/ibc.rs
@@ -2,13 +2,14 @@
 //! The IbcClient object provides helper function for ibc-related queries or actions.
 //!
 
+use crate::cw_helpers::cw_messages::AbstractMessage;
 use crate::{features::AccountIdentification, AbstractSdkResult};
 use abstract_core::{
     ibc_client::{CallbackInfo, ExecuteMsg as IbcClientMsg},
     ibc_host::HostAction,
     proxy::ExecuteMsg,
 };
-use cosmwasm_std::{wasm_execute, Coin, CosmosMsg, Deps};
+use cosmwasm_std::{wasm_execute, Coin, Deps};
 
 /// Interact with other chains over IBC.
 pub trait IbcInterface: AccountIdentification {
@@ -33,7 +34,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
         action: HostAction,
         callback: Option<CallbackInfo>,
         retries: u8,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         Ok(wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
             &ExecuteMsg::IbcAction {
@@ -53,7 +54,7 @@ impl<'a, T: IbcInterface> IbcClient<'a, T> {
         &self,
         receiving_chain: String,
         funds: Vec<Coin>,
-    ) -> AbstractSdkResult<CosmosMsg> {
+    ) -> AbstractSdkResult<AbstractMessage> {
         Ok(wasm_execute(
             self.base.proxy_address(self.deps)?.to_string(),
             &ExecuteMsg::IbcAction {
@@ -105,7 +106,7 @@ mod test {
             .unwrap(),
             funds: vec![],
         });
-        assert_that!(msg.unwrap()).is_equal_to(expected);
+        assert_that!(msg.unwrap()).is_equal_to::<AbstractMessage>(expected.into());
     }
 
     /// Tests that a host_action can be built with a callback with more retries
@@ -144,7 +145,7 @@ mod test {
             funds: vec![],
         });
 
-        assert_that!(actual.unwrap()).is_equal_to(expected);
+        assert_that!(actual.unwrap()).is_equal_to::<AbstractMessage>(expected.into());
     }
 
     /// Tests that the ics_20 transfer can be built and that the funds are passed into the sendFunds message not the execute message
@@ -171,6 +172,6 @@ mod test {
             // ensure empty
             funds: vec![],
         });
-        assert_that!(msg.unwrap()).is_equal_to(expected);
+        assert_that!(msg.unwrap()).is_equal_to::<AbstractMessage>(expected.into());
     }
 }

--- a/packages/abstract-sdk/src/apis/splitter.rs
+++ b/packages/abstract-sdk/src/apis/splitter.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+use crate::cw_helpers::cw_messages::{AbstractMessage, AbstractMessageMerge};
 use crate::{AbstractSdkResult, TransferInterface};
 use abstract_core::objects::AnsAsset;
 use cosmwasm_std::{Addr, CosmosMsg, Deps, StdResult, Uint128};
@@ -22,7 +23,7 @@ pub struct Splitter<'a, T: SplitterInterface> {
 
 impl<'a, T: SplitterInterface> Splitter<'a, T> {
     /// Split an asset to multiple users
-    pub fn split(&self, asset: AnsAsset, receivers: &[Addr]) -> AbstractSdkResult<Vec<CosmosMsg>> {
+    pub fn split(&self, asset: AnsAsset, receivers: &[Addr]) -> AbstractSdkResult<Vec<AbstractMessage>> {
         // split the asset between all receivers
         let receives_each = AnsAsset {
             amount: asset

--- a/packages/abstract-sdk/src/cw_helpers/cw_messages.rs
+++ b/packages/abstract-sdk/src/cw_helpers/cw_messages.rs
@@ -1,0 +1,99 @@
+use std::error::Error;
+use crate::{AbstractSdkResult, AbstractSdkError};
+
+use cosmwasm_std::{CosmosMsg, wasm_execute, WasmMsg};
+use abstract_core::proxy::ExecuteMsg;
+
+#[derive(Debug, PartialEq)]
+pub enum AbstractMessage{
+	ProxyMessage{
+		msgs: Vec<CosmosMsg>,
+		proxy: String,
+	},
+	Raw(CosmosMsg)
+}
+
+impl From<WasmMsg> for AbstractMessage{
+	fn from(m: WasmMsg) -> Self { 
+		AbstractMessage::Raw(CosmosMsg::Wasm(m))
+	}
+}
+
+impl From<CosmosMsg> for AbstractMessage{
+	fn from(m: CosmosMsg) -> Self { 
+		AbstractMessage::Raw(m)
+	}
+}
+
+impl From<AbstractMessage> for CosmosMsg{
+	fn from(msg: AbstractMessage) -> Self { 
+		match msg{
+			AbstractMessage::ProxyMessage{
+				msgs,
+				proxy
+			} => wasm_execute(proxy, &ExecuteMsg::ModuleAction { msgs }, vec![]).unwrap().into(),
+			AbstractMessage::Raw(msg) => msg
+		}
+	}
+}
+
+impl AbstractMessage{
+	pub fn from_proxy_msg(m: CosmosMsg, proxy: String) -> Self { 
+		Self::from_proxy_msgs(vec![m], proxy)
+	}
+
+	pub fn from_proxy_msgs(m: Vec<CosmosMsg>, proxy: String) -> Self { 
+		AbstractMessage::ProxyMessage{
+			msgs: m,
+			proxy
+		}
+	}
+}
+
+pub trait AbstractMessageMerge{
+	fn merge(&self) -> AbstractSdkResult<Vec<CosmosMsg>>;
+}
+
+impl AbstractMessageMerge for Vec<AbstractMessage>{
+
+	fn merge(&self) -> AbstractSdkResult<Vec<CosmosMsg>> {
+		
+		let mut merged_proxy_messages = Vec::new();
+	    let mut all_proxy = "";
+
+	    for message in self {
+	        match message {
+	            AbstractMessage::ProxyMessage { msgs, proxy } => {
+	            	if all_proxy.ne("") && proxy.ne(all_proxy){
+	            		return Err(AbstractSdkError::generic_err("Multiple proxy addresses were defined, not possible"))
+	            	}
+	                merged_proxy_messages.extend(msgs.clone());
+	                all_proxy = proxy;
+	            }
+	            AbstractMessage::Raw(cosmos_msg) => {
+	                merged_proxy_messages.push(cosmos_msg.clone());
+	            }
+	        }
+	    }
+	    Ok(merged_proxy_messages)
+	}
+}
+
+pub trait ConvertToAbstractMessage{
+	fn into_abstract_messages(self) -> AbstractSdkResult<Vec<AbstractMessage>>;
+}
+
+impl<T: Error> ConvertToAbstractMessage for Result<Vec<CosmosMsg>, T>{
+
+	fn into_abstract_messages(self) -> AbstractSdkResult<Vec<AbstractMessage>> {
+		
+		match self{
+			Ok(messages) => {
+				Ok(messages.iter().map(|msg| msg.clone().into()).collect())
+			},
+			Err(e) => Err(AbstractSdkError::generic_err(e.to_string()))
+		}
+	}
+}
+
+

--- a/packages/abstract-sdk/src/cw_helpers/cw_messages.rs
+++ b/packages/abstract-sdk/src/cw_helpers/cw_messages.rs
@@ -55,7 +55,6 @@ pub trait AbstractMessageMerge{
 }
 
 impl AbstractMessageMerge for Vec<AbstractMessage>{
-
 	fn merge(&self) -> AbstractSdkResult<Vec<CosmosMsg>> {
 		
 		let mut merged_proxy_messages = Vec::new();
@@ -78,22 +77,3 @@ impl AbstractMessageMerge for Vec<AbstractMessage>{
 	    Ok(merged_proxy_messages)
 	}
 }
-
-pub trait ConvertToAbstractMessage{
-	fn into_abstract_messages(self) -> AbstractSdkResult<Vec<AbstractMessage>>;
-}
-
-impl<T: Error> ConvertToAbstractMessage for Result<Vec<CosmosMsg>, T>{
-
-	fn into_abstract_messages(self) -> AbstractSdkResult<Vec<AbstractMessage>> {
-		
-		match self{
-			Ok(messages) => {
-				Ok(messages.iter().map(|msg| msg.clone().into()).collect())
-			},
-			Err(e) => Err(AbstractSdkError::generic_err(e.to_string()))
-		}
-	}
-}
-
-

--- a/packages/abstract-sdk/src/cw_helpers/mod.rs
+++ b/packages/abstract-sdk/src/cw_helpers/mod.rs
@@ -4,3 +4,4 @@ pub mod cosmwasm_std;
 pub mod cw_ownable;
 pub mod cw_storage_plus;
 pub mod fees;
+pub mod cw_messages;


### PR DESCRIPTION
This PR aims at allowing for more flexibility in execute and Proxy msgs in apps. 

This introduces a new enum AbstractMessage, that can either be a normal CosmosMsg or a Proxy Message, that is a message that will be called by the proxy directly. 

The targeted behavior is that when calling the proxy, all proxy messages should be called together to reduce gas costs

## Issues
Merging all proxy messages into a single ProxyMessage can give back unexpected results because the order of the message is not respected in the current implementation. We maybe should keep the original message order when merging messages