### PR TITLE
Add files via upload

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,24 @@
+# Frequently Asked Questions (FAQ)
+
+1. **What is Abstract?**
+Abstract is a revolutionary platform that empowers developers to create secure and powerful financial applications with ease. It provides a modular architecture and comprehensive tools to simplify the development process and enable the creation of innovative solutions in the blockchain space.
+
+2. **Who can use Abstract?**
+Abstract is designed for developers who want to build decentralized finance (DeFi) applications and leverage the benefits of blockchain technology. Whether you are an experienced blockchain developer or new to the space, Abstract provides the necessary tools and resources to facilitate your journey.
+
+3. **How can I get started with Abstract?**
+To get started with Abstract, visit our official website and access the documentation section. You will find comprehensive guides, tutorials, and resources to help you understand the platform's features and functionality. Additionally, you can join our developer community on Discord to connect with like-minded developers and seek assistance if needed.
+
+4. **Can I contribute to the Abstract ecosystem?**
+Absolutely! Abstract values community contributions and welcomes developers to contribute to the platform's growth. You can contribute by creating modules, sharing your insights and knowledge, participating in discussions, and collaborating on open-source projects. Visit our Contributing page in the documentation to learn more about how you can get involved.
+
+5. **How does Abstract ensure the security of financial applications?**
+Abstract is built on robust blockchain technology, which provides inherent security features such as immutability and decentralized consensus. The platform implements advanced cryptographic protocols and smart contract frameworks to ensure the integrity and security of financial applications built using Abstract. Additionally, the modular architecture allows developers to leverage pre-built functionalities and best practices, reducing the risk of vulnerabilities. Abstract also is partnered with Oak Security (https://www.oaksecurity.io/) to ensure our Modules are all able up to standard.
+
+6. **What kind of support does Abstract offer?**
+Abstract provides comprehensive support to developers through various channels. You can access our developer documentation, which includes step-by-step guides, API references, and sample code. We also have a dedicated support channel, such as our developer forum or Discord community, where you can seek assistance, share experiences, and collaborate with other developers.
+
+7. **How can I stay updated with Abstract's latest developments?**
+To stay updated with Abstract's latest developments, news, and announcements, you can follow our official social media accounts on platforms like Twitter and LinkedIn. Additionally, regularly check our website and subscribe to our newsletter to receive updates directly in your inbox.
+
+8. **I've been hearing a lot about this cw-orchestrator. Where can I learn more and begin using it?**


### PR DESCRIPTION
We need to fill out Q8 with a link to cw-orchestrator (not totally sure where you want that to redirect to). Also, maybe not a bad idea to link to the cw-orch docs and shoot the (https://crates.io/crates/cw-orch) page in there too?

Ideally, we eventually have something on our home page at abstract.money that has all of our product offerings as those grow. Possibly adding in cw-orch at this point is also good just to kind of put our stamp on it as a branding thing; maybe cw-orchestrator brought to you by Abstract or something along those lines