### PR TITLE
Feature/add namespace fee

### DIFF
--- a/contracts/native/version-control/Cargo.toml
+++ b/contracts/native/version-control/Cargo.toml
@@ -31,6 +31,7 @@ abstract-sdk = { workspace = true }
 abstract-core = { workspace = true }
 abstract-macros = { workspace = true }
 cw-ownable = { workspace = true }
+cw-asset = { workspace = true }
 
 
 [dev-dependencies]

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -1,6 +1,7 @@
 use abstract_core::objects::module::{self, Module};
 use cosmwasm_std::{
-    ensure, Addr, Attribute, Deps, DepsMut, MessageInfo, Order, QuerierWrapper, Response, StdResult, Storage, Uint128, Env
+    ensure, Addr, Attribute, Deps, DepsMut, Env, MessageInfo, Order, QuerierWrapper, Response,
+    StdResult, Storage, Uint128,
 };
 
 use abstract_sdk::{
@@ -20,7 +21,7 @@ use abstract_sdk::{
 use crate::contract::{VCResult, VcResponse, ABSTRACT_NAMESPACE};
 use crate::error::VCError;
 use crate::util::validate_sent_funds;
-use cw_asset::{Asset};
+use cw_asset::Asset;
 
 /// Add new Account to version control contract
 /// Only Factory can add Account
@@ -235,7 +236,7 @@ pub fn claim_namespaces(
     }
 
     let mut fee_messages = vec![];
-     // We transfer the namespace fee if necessary
+    // We transfer the namespace fee if necessary
     if fee.amount != Uint128::zero() {
         let admin_account = ACCOUNT_ADDRESSES.load(deps.storage, 0)?;
         let nb_namespaces: u128 = namespaces_to_claim.len().try_into().unwrap();
@@ -243,7 +244,12 @@ pub fn claim_namespaces(
             amount: fee.amount * Uint128::from(nb_namespaces),
             info: fee.info,
         };
-        fee_messages.extend(validate_sent_funds(necessary_fee, env, msg_info, Some(admin_account.proxy))?)
+        fee_messages.extend(validate_sent_funds(
+            necessary_fee,
+            env,
+            msg_info,
+            Some(admin_account.proxy),
+        )?)
     }
 
     for namespace in namespaces_to_claim.iter() {
@@ -624,10 +630,10 @@ mod test {
     mod claim_namespaces {
         use super::*;
         use abstract_core::objects;
-        use cosmwasm_std::{coins, CosmosMsg, SubMsg, BankMsg};
+        use cosmwasm_std::{coins, BankMsg, CosmosMsg, SubMsg};
 
+        use cw_asset::AssetInfo;
         use objects::ABSTRACT_ACCOUNT_ID;
-        use cw_asset::{AssetInfo};
 
         #[test]
         fn claim_namespaces_by_owner() -> VersionControlTestResult {

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -1,7 +1,8 @@
+use cosmwasm_std::CosmosMsg;
 use abstract_core::objects::module::{self, Module};
 use cosmwasm_std::{
     ensure, Addr, Attribute, Deps, DepsMut, MessageInfo, Order, QuerierWrapper, Response,
-    StdResult, Storage,
+    StdResult, Storage,BankMsg,StdError,Uint128
 };
 
 use abstract_sdk::{
@@ -20,6 +21,7 @@ use abstract_sdk::{
 
 use crate::contract::{VCResult, VcResponse, ABSTRACT_NAMESPACE};
 use crate::error::VCError;
+use cw_asset::{Asset, AssetInfoBase};
 
 /// Add new Account to version control contract
 /// Only Factory can add Account
@@ -215,6 +217,7 @@ pub fn claim_namespaces(
 
     let Config {
         namespace_limit: namespaces_limit,
+        namespace_registration_fee: fee,
         ..
     } = CONFIG.load(deps.storage)?;
     let limit = namespaces_limit as usize;
@@ -229,6 +232,29 @@ pub fn claim_namespaces(
             limit,
             current: existing_namespace_count,
         });
+    }
+
+    let mut fee_messages = vec![];
+    // We transfer the fee if necessary
+    if fee.amount != Uint128::zero(){
+        let admin_account = ACCOUNT_ADDRESSES.load(deps.storage, 0)?;
+        let nb_namespaces: u128 = namespaces_to_claim.len().try_into().unwrap();
+        let necessary_fee = Asset{
+            amount: fee.amount * Uint128::from(nb_namespaces),
+            info: fee.info.clone()
+        };
+        match &fee.info{
+            AssetInfoBase::Native(d)=> {
+                if msg_info.funds.len() != 1 || msg_info.funds[0].denom != d.clone() || necessary_fee.amount != msg_info.funds[0].amount {
+                    return Err(VCError::InvalidFeePayment { expected: necessary_fee, sent: msg_info.funds })
+                }
+                fee_messages.push(CosmosMsg::Bank(BankMsg::Send { to_address: admin_account.proxy.to_string(), amount: msg_info.funds}))
+            },
+            AssetInfoBase::Cw20(_) => {
+                fee_messages.push(necessary_fee.transfer_from_msg(msg_info.sender, admin_account.proxy)?)
+            }
+            _ => return Err(VCError::Std(StdError::generic_err("Unreachable")))
+        }
     }
 
     for namespace in namespaces_to_claim.iter() {
@@ -248,7 +274,7 @@ pub fn claim_namespaces(
             ("account_id", &account_id.to_string()),
             ("namespaces", &namespaces_to_claim.join(",")),
         ],
-    ))
+    ).add_messages(fee_messages))
 }
 
 /// Remove namespaces
@@ -304,6 +330,7 @@ pub fn update_config(
     info: MessageInfo,
     allow_direct_module_registration: Option<bool>,
     namespace_limit: Option<u32>,
+    namespace_registration_fee: Option<Asset>
 ) -> VCResult {
     cw_ownable::assert_owner(deps.storage, &info.sender)?;
     let mut config = CONFIG.load(deps.storage)?;
@@ -335,6 +362,18 @@ pub fn update_config(
                 previous_allow.to_string(),
             ),
             ("allow_direct_module_registration", allow.to_string()),
+        ])
+    }
+
+    if let Some(fee) = namespace_registration_fee {
+        let previous_fee = config.namespace_registration_fee;
+        config.namespace_registration_fee = fee.clone();
+        attributes.extend(vec![
+            (
+                "previous_allow_direct_module_registration",
+                format!("{:?}",previous_fee),
+            ),
+            ("allow_direct_module_registration", fee.to_string()),
         ])
     }
 
@@ -387,7 +426,7 @@ pub fn set_factory(deps: DepsMut, info: MessageInfo, new_admin: String) -> VCRes
 #[cfg(test)]
 mod test {
     use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
-    use cosmwasm_std::{from_binary, to_binary, Addr, Uint64};
+    use cosmwasm_std::{from_binary, to_binary, Addr, Uint64, Coin};
     use cw_controllers::AdminError;
     use cw_ownable::OwnershipError;
     use speculoos::prelude::*;
@@ -450,6 +489,7 @@ mod test {
             InstantiateMsg {
                 allow_direct_module_registration: Some(true),
                 namespace_limit: 10,
+                namespace_registration_fee: None,
             },
         )?;
         execute_as_admin(
@@ -470,6 +510,7 @@ mod test {
             InstantiateMsg {
                 allow_direct_module_registration: Some(direct_registration),
                 namespace_limit: 10,
+                namespace_registration_fee: None,
             },
         )?;
         execute_as_admin(
@@ -493,6 +534,10 @@ mod test {
 
     fn execute_as(deps: DepsMut, sender: &str, msg: ExecuteMsg) -> VCResult {
         contract::execute(deps, mock_env(), mock_info(sender, &[]), msg)
+    }
+
+    fn execute_as_with_funds(deps: DepsMut, sender: &str, msg: ExecuteMsg, funds: &[Coin]) -> VCResult {
+        contract::execute(deps, mock_env(), mock_info(sender, funds), msg)
     }
 
     fn execute_as_admin(deps: DepsMut, msg: ExecuteMsg) -> VCResult {
@@ -584,6 +629,8 @@ mod test {
     mod claim_namespaces {
         use super::*;
         use abstract_core::objects;
+        use cosmwasm_std::{coins, SubMsg, CosmosMsg};
+
         use objects::ABSTRACT_ACCOUNT_ID;
 
         #[test]
@@ -603,6 +650,118 @@ mod test {
             assert_that!(account_id).is_equal_to(TEST_ACCOUNT_ID);
             let account_id = namespaces_info().load(&deps.storage, &new_namespace2)?;
             assert_that!(account_id).is_equal_to(TEST_ACCOUNT_ID);
+            Ok(())
+        }
+
+        #[test]
+        fn claim_namespaces_with_coin_fee() -> VersionControlTestResult {
+            let mut deps = mock_dependencies();
+            deps.querier = mock_manager_querier().build();
+
+            mock_init_with_account(deps.as_mut(), true)?;
+
+            let one_namespace_fee = Asset{info: AssetInfoBase::Native("ujunox".to_string()), amount: 6u128.into()};
+
+            execute_as_admin(deps.as_mut(), ExecuteMsg::UpdateConfig { 
+                allow_direct_module_registration: None,
+                namespace_limit: None, 
+                namespace_registration_fee: Some(one_namespace_fee.clone()) 
+            }).unwrap();
+
+            // We create a 0 admin account
+            const TEST_ADMIN_PROXY: &str =  "test-admin-proxy";
+            execute_as(
+                deps.as_mut(),
+                TEST_ACCOUNT_FACTORY,
+                ExecuteMsg::AddAccount {
+                    account_id: 0,
+                    account_base: AccountBase {
+                        manager: Addr::unchecked(TEST_MANAGER),
+                        proxy: Addr::unchecked(TEST_ADMIN_PROXY),
+                    },
+                },
+            ).unwrap();
+
+            let new_namespace1 = Namespace::new("namespace1").unwrap();
+            let new_namespace2 = Namespace::new("namespace2").unwrap();
+            let msg = ExecuteMsg::ClaimNamespaces {
+                account_id: TEST_ACCOUNT_ID,
+                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+            };
+            // Fail, no fee at all
+            let res = execute_as(deps.as_mut(), TEST_OWNER, msg.clone());
+            assert_that!(&res).is_err()
+                .is_equal_to(&VCError::InvalidFeePayment { expected: Asset{
+                    info: one_namespace_fee.info.clone(),
+                    amount: one_namespace_fee.amount * Uint128::from(2u128)
+                }, sent: vec![] });
+
+            // Fail, not enough fee
+            let sent_coins = coins(5, "ujunox");
+            let res = execute_as_with_funds(deps.as_mut(), TEST_OWNER, msg.clone(), &sent_coins);
+            assert_that!(&res).is_err()
+                .is_equal_to(&VCError::InvalidFeePayment { expected: Asset{
+                    info: one_namespace_fee.info.clone(),
+                    amount: one_namespace_fee.amount * Uint128::from(2u128)
+                }, sent: sent_coins});
+
+            // Success
+            let sent_coins = coins(12, "ujunox");
+            let res = execute_as_with_funds(deps.as_mut(), TEST_OWNER, msg, &sent_coins);
+            assert_that!(&res)
+                .is_ok()
+                .map(|res| &res.messages)
+                .is_equal_to(vec![SubMsg::new(CosmosMsg::Bank(BankMsg::Send { to_address: TEST_ADMIN_PROXY.to_string(), amount: sent_coins}))]);
+
+            Ok(())
+        }
+
+        #[test]
+        fn claim_namespaces_with_cw20_fee() -> VersionControlTestResult {
+            let mut deps = mock_dependencies();
+            deps.querier = mock_manager_querier().build();
+
+            mock_init_with_account(deps.as_mut(), true)?;
+
+            let one_namespace_fee = Asset{info: AssetInfoBase::Cw20(Addr::unchecked("abstract_token")), amount: 6u128.into()};
+
+            execute_as_admin(deps.as_mut(), ExecuteMsg::UpdateConfig { 
+                allow_direct_module_registration: None,
+                namespace_limit: None, 
+                namespace_registration_fee: Some(one_namespace_fee.clone()) 
+            }).unwrap();
+
+            // We create a 0 admin account
+            const TEST_ADMIN_PROXY: &str =  "test-admin-proxy";
+            execute_as(
+                deps.as_mut(),
+                TEST_ACCOUNT_FACTORY,
+                ExecuteMsg::AddAccount {
+                    account_id: 0,
+                    account_base: AccountBase {
+                        manager: Addr::unchecked(TEST_MANAGER),
+                        proxy: Addr::unchecked(TEST_ADMIN_PROXY),
+                    },
+                },
+            ).unwrap();
+
+            let new_namespace1 = Namespace::new("namespace1").unwrap();
+            let new_namespace2 = Namespace::new("namespace2").unwrap();
+            let msg = ExecuteMsg::ClaimNamespaces {
+                account_id: TEST_ACCOUNT_ID,
+                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+            };
+            // Success
+            let res = execute_as(deps.as_mut(), TEST_OWNER, msg);
+            let expected_fee = Asset{
+                info: one_namespace_fee.info,
+                amount: one_namespace_fee.amount * Uint128::from(2u128)
+            };
+            assert_that!(&res)
+                .is_ok()
+                .map(|res| &res.messages)
+                .is_equal_to(vec![SubMsg::new(expected_fee.transfer_from_msg(TEST_OWNER, TEST_ADMIN_PROXY)?)]);
+
             Ok(())
         }
 
@@ -724,6 +883,7 @@ mod test {
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: None,
                 namespace_limit: Some(100),
+                namespace_registration_fee: None,
             };
 
             let res = execute_as(deps.as_mut(), TEST_OTHER, msg);
@@ -742,6 +902,7 @@ mod test {
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: None,
                 namespace_limit: Some(100),
+                namespace_registration_fee: None,
             };
 
             let res = execute_as_admin(deps.as_mut(), msg);
@@ -760,6 +921,7 @@ mod test {
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: None,
                 namespace_limit: Some(0),
+                namespace_registration_fee: None,
             };
 
             let res = execute_as_admin(deps.as_mut(), msg);
@@ -785,6 +947,7 @@ mod test {
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: Some(false),
                 namespace_limit: None,
+                namespace_registration_fee: None,
             };
 
             let res = execute_as(deps.as_mut(), TEST_OTHER, msg);
@@ -803,6 +966,7 @@ mod test {
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: Some(false),
                 namespace_limit: None,
+                namespace_registration_fee: None,
             };
 
             let res = execute_as_admin(deps.as_mut(), msg);
@@ -816,6 +980,58 @@ mod test {
                     .allow_direct_module_registration
             )
             .is_equal_to(false);
+
+            Ok(())
+        }
+    }
+
+    mod update_namespace_fee {
+        use cw_asset::{AssetInfoBase, Asset};
+        use super::*;
+
+        #[test]
+        fn only_admin() -> VersionControlTestResult {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut())?;
+
+            let msg = ExecuteMsg::UpdateConfig {
+                allow_direct_module_registration: None,
+                namespace_limit: None,
+                namespace_registration_fee: Some(Asset { info: AssetInfoBase::Native("ujunox".to_string()), amount: Uint128::one() }),
+            };
+
+            let res = execute_as(deps.as_mut(), TEST_OTHER, msg);
+            assert_that!(&res)
+                .is_err()
+                .is_equal_to(&VCError::Ownership(OwnershipError::NotOwner));
+
+            Ok(())
+        }
+
+        #[test]
+        fn updates_limit() -> VersionControlTestResult {
+            let mut deps = mock_dependencies();
+            mock_init(deps.as_mut())?;
+
+            let new_fee = Asset { info: AssetInfoBase::Native("ujunox".to_string()), amount: Uint128::one() };
+
+            let msg = ExecuteMsg::UpdateConfig {
+                allow_direct_module_registration: None,
+                namespace_limit: None,
+                namespace_registration_fee: Some(new_fee.clone()),
+            };
+
+            let res = execute_as_admin(deps.as_mut(), msg);
+            assert_that!(&res).is_ok();
+
+            assert_that!(CONFIG.load(&deps.storage).unwrap().namespace_limit).is_equal_to(10);
+            assert_that!(
+                CONFIG
+                    .load(&deps.storage)
+                    .unwrap()
+                    .namespace_registration_fee
+            )
+            .is_equal_to(new_fee);
 
             Ok(())
         }

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -87,7 +87,7 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
         ExecuteMsg::ClaimNamespaces {
             account_id,
             namespaces,
-        } => claim_namespaces(deps, info, account_id, namespaces),
+        } => claim_namespaces(deps, env, info, account_id, namespaces),
         ExecuteMsg::RemoveNamespaces { namespaces } => remove_namespaces(deps, info, namespaces),
         ExecuteMsg::AddAccount {
             account_id,

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -1,4 +1,5 @@
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response, Uint128};
+use cw_asset::{Asset, AssetInfoBase};
 use cw_semver::Version;
 
 use abstract_core::objects::namespace::Namespace;
@@ -44,6 +45,7 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
     let InstantiateMsg {
         allow_direct_module_registration,
         namespace_limit,
+        namespace_registration_fee
     } = msg;
 
     CONFIG.save(
@@ -51,6 +53,7 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
         &Config {
             allow_direct_module_registration: allow_direct_module_registration.unwrap_or(false),
             namespace_limit,
+            namespace_registration_fee: namespace_registration_fee.unwrap_or(Asset{info: AssetInfoBase::Native("none".to_string()), amount: Uint128::zero()})
         },
     )?;
 
@@ -90,11 +93,13 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
         ExecuteMsg::UpdateConfig {
             allow_direct_module_registration,
             namespace_limit,
+            namespace_registration_fee,
         } => update_config(
             deps,
             info,
             allow_direct_module_registration,
             namespace_limit,
+            namespace_registration_fee,
         ),
         ExecuteMsg::SetFactory { new_factory } => set_factory(deps, info, new_factory),
         ExecuteMsg::UpdateOwnership(action) => {

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -45,7 +45,7 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
     let InstantiateMsg {
         allow_direct_module_registration,
         namespace_limit,
-        namespace_registration_fee
+        namespace_registration_fee,
     } = msg;
 
     CONFIG.save(
@@ -53,7 +53,10 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
         &Config {
             allow_direct_module_registration: allow_direct_module_registration.unwrap_or(false),
             namespace_limit,
-            namespace_registration_fee: namespace_registration_fee.unwrap_or(Asset{info: AssetInfoBase::Native("none".to_string()), amount: Uint128::zero()})
+            namespace_registration_fee: namespace_registration_fee.unwrap_or(Asset {
+                info: AssetInfoBase::Native("none".to_string()),
+                amount: Uint128::zero(),
+            }),
         },
     )?;
 

--- a/contracts/native/version-control/src/error.rs
+++ b/contracts/native/version-control/src/error.rs
@@ -76,7 +76,7 @@ pub enum VCError {
     NoAction,
 
     #[error("Invalid fee payment sent. Expected {}, sent {:?}", expected, sent)]
-    InvalidFeePayment {expected: Asset, sent: Vec<Coin>}
+    InvalidFeePayment { expected: Asset, sent: Vec<Coin> },
 }
 
 impl From<cw_semver::Error> for VCError {

--- a/contracts/native/version-control/src/error.rs
+++ b/contracts/native/version-control/src/error.rs
@@ -1,3 +1,4 @@
+use cosmwasm_std::Coin;
 use cosmwasm_std::{Addr, StdError};
 use cw_controllers::AdminError;
 use thiserror::Error;
@@ -5,6 +6,8 @@ use thiserror::Error;
 use abstract_core::objects::namespace::Namespace;
 use abstract_core::{objects::AccountId, AbstractError};
 use abstract_sdk::{core::objects::module::ModuleInfo, AbstractSdkError};
+
+use cw_asset::{Asset, AssetError};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum VCError {
@@ -19,6 +22,9 @@ pub enum VCError {
 
     #[error("{0}")]
     Admin(#[from] AdminError),
+
+    #[error("{0}")]
+    Assets(#[from] AssetError),
 
     #[error("{0}")]
     Ownership(#[from] cw_ownable::OwnershipError),
@@ -68,6 +74,9 @@ pub enum VCError {
 
     #[error("No action specified")]
     NoAction,
+
+    #[error("Invalid fee payment sent. Expected {}, sent {:?}", expected, sent)]
+    InvalidFeePayment {expected: Asset, sent: Vec<Coin>}
 }
 
 impl From<cw_semver::Error> for VCError {

--- a/contracts/native/version-control/src/lib.rs
+++ b/contracts/native/version-control/src/lib.rs
@@ -23,7 +23,7 @@ mod testing {
             version_control::InstantiateMsg {
                 allow_direct_module_registration: Some(true),
                 namespace_limit: 10,
-                namespace_registration_fee: None
+                namespace_registration_fee: None,
             },
         )
     }

--- a/contracts/native/version-control/src/lib.rs
+++ b/contracts/native/version-control/src/lib.rs
@@ -2,7 +2,7 @@ pub mod commands;
 pub mod contract;
 pub mod error;
 pub mod queries;
-
+mod util;
 #[cfg(test)]
 mod testing {
     use crate::contract;

--- a/contracts/native/version-control/src/lib.rs
+++ b/contracts/native/version-control/src/lib.rs
@@ -23,6 +23,7 @@ mod testing {
             version_control::InstantiateMsg {
                 allow_direct_module_registration: Some(true),
                 namespace_limit: 10,
+                namespace_registration_fee: None
             },
         )
     }

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -316,7 +316,7 @@ mod test {
             InstantiateMsg {
                 allow_direct_module_registration: Some(true),
                 namespace_limit: 10,
-                namespace_registration_fee: None
+                namespace_registration_fee: None,
             },
         )?;
         execute_as_admin(

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -316,6 +316,7 @@ mod test {
             InstantiateMsg {
                 allow_direct_module_registration: Some(true),
                 namespace_limit: 10,
+                namespace_registration_fee: None
             },
         )?;
         execute_as_admin(

--- a/contracts/native/version-control/src/util.rs
+++ b/contracts/native/version-control/src/util.rs
@@ -1,10 +1,13 @@
+use crate::{contract::VCResult, error::VCError};
 
-use crate::{error::VCError, contract::VCResult};
-
+use cosmwasm_std::{Addr, BankMsg, CosmosMsg, Env, MessageInfo, StdError};
 use cw_asset::{Asset, AssetInfo};
-use cosmwasm_std::{ Addr, StdError, CosmosMsg, MessageInfo, BankMsg, Env};
-pub fn validate_sent_funds(fee: Asset, env: Env, msg_info: MessageInfo, receiver: Option<Addr>) -> VCResult<Vec<CosmosMsg>>{
-
+pub fn validate_sent_funds(
+    fee: Asset,
+    env: Env,
+    msg_info: MessageInfo,
+    receiver: Option<Addr>,
+) -> VCResult<Vec<CosmosMsg>> {
     let mut fee_messages = vec![];
     match &fee.info {
         AssetInfo::Native(d) => {
@@ -23,11 +26,10 @@ pub fn validate_sent_funds(fee: Asset, env: Env, msg_info: MessageInfo, receiver
             }))
         }
         AssetInfo::Cw20(_) => {
-        	if let Some(receiver) = receiver{
-        		fee_messages
-            		.push(fee.transfer_from_msg(msg_info.sender, receiver)?)
+            if let Some(receiver) = receiver {
+                fee_messages.push(fee.transfer_from_msg(msg_info.sender, receiver)?)
             }
-        },
+        }
         _ => return Err(VCError::Std(StdError::generic_err("Unreachable"))),
     }
 

--- a/contracts/native/version-control/src/util.rs
+++ b/contracts/native/version-control/src/util.rs
@@ -1,0 +1,35 @@
+
+use crate::{error::VCError, contract::VCResult};
+
+use cw_asset::{Asset, AssetInfo};
+use cosmwasm_std::{ Addr, StdError, CosmosMsg, MessageInfo, BankMsg, Env};
+pub fn validate_sent_funds(fee: Asset, env: Env, msg_info: MessageInfo, receiver: Option<Addr>) -> VCResult<Vec<CosmosMsg>>{
+
+    let mut fee_messages = vec![];
+    match &fee.info {
+        AssetInfo::Native(d) => {
+            if msg_info.funds.len() != 1
+                || msg_info.funds[0].denom != d.clone()
+                || fee.amount != msg_info.funds[0].amount
+            {
+                return Err(VCError::InvalidFeePayment {
+                    expected: fee,
+                    sent: msg_info.funds,
+                });
+            }
+            fee_messages.push(CosmosMsg::Bank(BankMsg::Send {
+                to_address: receiver.unwrap_or(env.contract.address).to_string(),
+                amount: msg_info.funds,
+            }))
+        }
+        AssetInfo::Cw20(_) => {
+        	if let Some(receiver) = receiver{
+        		fee_messages
+            		.push(fee.transfer_from_msg(msg_info.sender, receiver)?)
+            }
+        },
+        _ => return Err(VCError::Std(StdError::generic_err("Unreachable"))),
+    }
+
+    Ok(fee_messages)
+}

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -15,6 +15,7 @@ pub type ModuleMapEntry = (ModuleInfo, ModuleReference);
 pub struct Config {
     pub allow_direct_module_registration: bool,
     pub namespace_limit: u32,
+    pub namespace_registration_fee: Asset
 }
 
 pub mod state {
@@ -63,6 +64,7 @@ pub fn namespaces_info<'a>() -> IndexedMap<'a, &'a Namespace, AccountId, Namespa
     IndexedMap::new("namespace", indexes)
 }
 
+use cw_asset::Asset;
 use crate::objects::{
     account_id::AccountId,
     module::{Module, ModuleInfo, ModuleStatus},
@@ -85,6 +87,7 @@ pub struct AccountBase {
 pub struct InstantiateMsg {
     pub allow_direct_module_registration: Option<bool>,
     pub namespace_limit: u32,
+    pub namespace_registration_fee: Option<Asset>
 }
 
 /// Version Control Execute Msg
@@ -128,6 +131,7 @@ pub enum ExecuteMsg {
     UpdateConfig {
         allow_direct_module_registration: Option<bool>,
         namespace_limit: Option<u32>,
+        namespace_registration_fee: Option<Asset>
     },
     /// Sets a new Factory
     SetFactory { new_factory: String },

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -15,7 +15,7 @@ pub type ModuleMapEntry = (ModuleInfo, ModuleReference);
 pub struct Config {
     pub allow_direct_module_registration: bool,
     pub namespace_limit: u32,
-    pub namespace_registration_fee: Asset
+    pub namespace_registration_fee: Asset,
 }
 
 pub mod state {
@@ -64,7 +64,6 @@ pub fn namespaces_info<'a>() -> IndexedMap<'a, &'a Namespace, AccountId, Namespa
     IndexedMap::new("namespace", indexes)
 }
 
-use cw_asset::Asset;
 use crate::objects::{
     account_id::AccountId,
     module::{Module, ModuleInfo, ModuleStatus},
@@ -73,6 +72,7 @@ use crate::objects::{
 };
 use cosmwasm_schema::QueryResponses;
 use cosmwasm_std::Addr;
+use cw_asset::Asset;
 use cw_storage_plus::{Index, IndexList, IndexedMap, MultiIndex};
 
 /// Contains the minimal Abstract Account contract addresses.
@@ -87,7 +87,7 @@ pub struct AccountBase {
 pub struct InstantiateMsg {
     pub allow_direct_module_registration: Option<bool>,
     pub namespace_limit: u32,
-    pub namespace_registration_fee: Option<Asset>
+    pub namespace_registration_fee: Option<Asset>,
 }
 
 /// Version Control Execute Msg
@@ -131,7 +131,7 @@ pub enum ExecuteMsg {
     UpdateConfig {
         allow_direct_module_registration: Option<bool>,
         namespace_limit: Option<u32>,
-        namespace_registration_fee: Option<Asset>
+        namespace_registration_fee: Option<Asset>,
     },
     /// Sets a new Factory
     SetFactory { new_factory: String },

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -143,6 +143,7 @@ impl<Chain: CwEnv> Abstract<Chain> {
             &abstract_core::version_control::InstantiateMsg {
                 allow_direct_module_registration: Some(true),
                 namespace_limit: 1,
+                namespace_registration_fee: None,
             },
             Some(sender),
             None,


### PR DESCRIPTION
This PR aims at introducing a fee for registering a new namespace. This fee can either be a cw20 or a native token.
We introduce the `validate_sent_funds` function that verifies the sent funds match the fee ans send that fee to a registered address. It could be separated from the crate and into a utils crate because this can be useful more generally

In the claim namespace

## Improvements
- [ ] The only way to set a null fee for claiming a namespace is specifying a 0 amount inside the fee object. In order to stay closer to Rust best practices, we could introduce an Option to wrap that fee in the config object. However, modifying the fee becomes difficult because you can't deserialize Option<Option<>> properly. Do you think it's worth changing ?
- [ ] Separate the validate_sent_funds and introduce it in the `BANK` api ?