### PR TITLE
Fix abstract-interface test-env version conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ abstract-app = { path = "packages/abstract-app" }
 
 # Keep these as path, creates cirular dependency otherwise
 # Only need to re-publish all contracts if a re-publish of abstract-interface is required
-abstract-interface = { path = "packages/abstract-interface" , version = "0.15.1" }
+abstract-interface = { path = "packages/abstract-interface", version = "0.15.1" }
 module-factory = { package = "abstract-module-factory", path = "contracts/native/module-factory" }
 account-factory = { package = "abstract-account-factory", path = "contracts/native/account-factory" }
 ans-host = { package = "abstract-ans-host", path = "contracts/native/ans-host" }

--- a/contracts/account/proxy/src/contract.rs
+++ b/contracts/account/proxy/src/contract.rs
@@ -18,7 +18,7 @@ use abstract_sdk::{
 use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
 use semver::Version;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[abstract_response(PROXY)]
 pub struct ProxyResponse;

--- a/contracts/ibc-hosts/osmosis/src/contract.rs
+++ b/contracts/ibc-hosts/osmosis/src/contract.rs
@@ -20,7 +20,7 @@ use cosmwasm_std::{
 use dex::host_exchange::Osmosis;
 use dex::LocalDex;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[abstract_response(OSMOSIS_HOST)]
 pub(crate) struct OsmosisHostResponse;

--- a/contracts/native/account-factory/src/contract.rs
+++ b/contracts/native/account-factory/src/contract.rs
@@ -9,7 +9,7 @@ use cosmwasm_std::{
 use abstract_sdk::{execute_update_ownership, query_ownership};
 use semver::Version;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[abstract_response(ACCOUNT_FACTORY)]
 pub struct AccountFactoryResponse;

--- a/contracts/native/ans-host/src/contract.rs
+++ b/contracts/native/ans-host/src/contract.rs
@@ -21,7 +21,7 @@ pub struct AnsHostResponse;
 
 pub type AnsHostResult<T = Response> = Result<T, AnsHostError>;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
 pub fn instantiate(

--- a/contracts/native/ibc-client/src/contract.rs
+++ b/contracts/native/ibc-client/src/contract.rs
@@ -14,7 +14,7 @@ use cosmwasm_std::{
 };
 use cw_semver::Version;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub(crate) const MAX_RETRIES: u8 = 5;
 
 pub(crate) type IbcClientResult<T = Response> = Result<T, IbcClientError>;

--- a/contracts/native/module-factory/src/contract.rs
+++ b/contracts/native/module-factory/src/contract.rs
@@ -8,7 +8,7 @@ use cosmwasm_std::{
 use cw2::set_contract_version;
 use semver::Version;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[abstract_response(MODULE_FACTORY)]
 pub struct ModuleFactoryResponse;

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -22,7 +22,7 @@ use crate::queries;
 
 pub(crate) use abstract_core::objects::namespace::ABSTRACT_NAMESPACE;
 
-const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub type VCResult<T = Response> = Result<T, VCError>;
 

--- a/packages/abstract-interface/Cargo.toml
+++ b/packages/abstract-interface/Cargo.toml
@@ -8,14 +8,7 @@ description = "Abstract deployment helpers with cw-orchestrator"
 [features]
 default = ["integration"]
 daemon = ["cw-orch/daemon"]
-integration = [
-  "dep:ans-host",
-  "dep:module-factory",
-  "dep:account-factory",
-  "dep:version-control",
-  "dep:proxy",
-  "dep:manager",
-]
+integration = []
 
 [dependencies]
 cosmwasm-std = { workspace = true }
@@ -37,12 +30,12 @@ serde_json = "1.0.79"
 speculoos = { workspace = true }
 
 # Keep these here
-module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.15.1", optional = true }
-account-factory = { package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false, version = "0.15.1", optional = true }
-ans-host = { package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false, version = "0.15.1", optional = true }
-version-control = { package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false, version = "0.15.1", optional = true }
-proxy = { package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false, version = "0.15.1", optional = true }
-manager = { package = "abstract-manager", path = "../../contracts/account/manager", default-features = false, version = "0.15.1", optional = true }
+module-factory = { package = "abstract-module-factory", path = "../../contracts/native/module-factory", default-features = false, version = "0.15.1" }
+account-factory = { package = "abstract-account-factory", path = "../../contracts/native/account-factory", default-features = false, version = "0.15.1" }
+ans-host = { package = "abstract-ans-host", path = "../../contracts/native/ans-host", default-features = false, version = "0.15.1" }
+version-control = { package = "abstract-version-control", path = "../../contracts/native/version-control", default-features = false, version = "0.15.1" }
+proxy = { package = "abstract-proxy", path = "../../contracts/account/proxy", default-features = false, version = "0.15.1" }
+manager = { package = "abstract-manager", path = "../../contracts/account/manager", default-features = false, version = "0.15.1" }
 
 [build-dependencies]
 serde_json = "1.0.79"

--- a/packages/abstract-interface/src/account/manager.rs
+++ b/packages/abstract-interface/src/account/manager.rs
@@ -14,7 +14,6 @@ use serde::Serialize;
 pub struct Manager<Chain>;
 
 impl<Chain: CwEnv> Uploadable for Manager<Chain> {
-    #[cfg(feature = "integration")]
     fn wrapper(&self) -> <Mock as TxHandler>::ContractSource {
         Box::new(
             ContractWrapper::new_with_empty(

--- a/packages/abstract-interface/src/account/mod.rs
+++ b/packages/abstract-interface/src/account/mod.rs
@@ -50,9 +50,8 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
     pub fn register(
         &self,
         version_control: &VersionControl<Chain>,
-        version: &str,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        version_control.register_base(self, version)
+        version_control.register_base(self)
     }
 
     pub fn install_module<TInitMsg: Serialize>(

--- a/packages/abstract-interface/src/deployers.rs
+++ b/packages/abstract-interface/src/deployers.rs
@@ -48,7 +48,7 @@ pub trait AdapterDeployer<Chain: CwEnv + ChainUpload, CustomInitMsg: Serialize>:
 
         abstr
             .version_control
-            .register_adapters(vec![(self.as_instance(),version.to_string())])?;
+            .register_adapters(vec![(self.as_instance(), version.to_string())])?;
         Ok(())
     }
 }
@@ -79,7 +79,7 @@ pub trait AppDeployer<Chain: CwEnv + ChainUpload>:
 
         abstr
             .version_control
-            .register_apps(vec![(self.as_instance(),version.to_string())])?;
+            .register_apps(vec![(self.as_instance(), version.to_string())])?;
         Ok(())
     }
 }

--- a/packages/abstract-interface/src/deployers.rs
+++ b/packages/abstract-interface/src/deployers.rs
@@ -48,7 +48,7 @@ pub trait AdapterDeployer<Chain: CwEnv + ChainUpload, CustomInitMsg: Serialize>:
 
         abstr
             .version_control
-            .register_adapters(vec![self.as_instance()], &version)?;
+            .register_adapters(vec![(self.as_instance(),version.to_string())])?;
         Ok(())
     }
 }
@@ -79,7 +79,7 @@ pub trait AppDeployer<Chain: CwEnv + ChainUpload>:
 
         abstr
             .version_control
-            .register_apps(vec![self.as_instance()], &version)?;
+            .register_apps(vec![(self.as_instance(),version.to_string())])?;
         Ok(())
     }
 }

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -11,7 +11,6 @@ use abstract_core::{
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
 
-
 pub struct Abstract<Chain: CwEnv> {
     pub ans_host: AnsHost<Chain>,
     pub version_control: VersionControl<Chain>,
@@ -172,12 +171,24 @@ impl<Chain: CwEnv> Abstract<Chain> {
         Ok(())
     }
 
-    pub fn contracts(&self) -> Vec<(&cw_orch::contract::Contract<Chain>,String)> {
+    pub fn contracts(&self) -> Vec<(&cw_orch::contract::Contract<Chain>, String)> {
         vec![
-            (self.ans_host.as_instance(),ans_host::contract::CONTRACT_VERSION.to_string()),
-            (self.version_control.as_instance(),version_control::contract::CONTRACT_VERSION.to_string()),
-            (self.account_factory.as_instance(),account_factory::contract::CONTRACT_VERSION.to_string()),
-            (self.module_factory.as_instance(),module_factory::contract::CONTRACT_VERSION.to_string()),
+            (
+                self.ans_host.as_instance(),
+                ans_host::contract::CONTRACT_VERSION.to_string(),
+            ),
+            (
+                self.version_control.as_instance(),
+                version_control::contract::CONTRACT_VERSION.to_string(),
+            ),
+            (
+                self.account_factory.as_instance(),
+                account_factory::contract::CONTRACT_VERSION.to_string(),
+            ),
+            (
+                self.module_factory.as_instance(),
+                module_factory::contract::CONTRACT_VERSION.to_string(),
+            ),
         ]
     }
 }

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use crate::{
     get_account_contracts, get_native_contracts, AbstractAccount, AbstractInterfaceError,
-    AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VersionControl, VERSION,
+    AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VersionControl,
 };
 use abstract_core::{
     objects::gov_type::GovernanceDetails, ACCOUNT_FACTORY, ANS_HOST, MANAGER, MODULE_FACTORY,
@@ -10,7 +10,7 @@ use abstract_core::{
 };
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
-use semver::Version;
+
 
 pub struct Abstract<Chain: CwEnv> {
     pub ans_host: AnsHost<Chain>,
@@ -56,8 +56,6 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
         // upload
         let mut deployment = Self::store_on(chain.clone())?;
 
-        let version: Version = VERSION.parse().unwrap();
-
         // ########### Instantiate ##############
         deployment.instantiate(&chain)?;
 
@@ -73,11 +71,11 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
 
         deployment
             .version_control
-            .register_base(&deployment.account, &version.to_string())?;
+            .register_base(&deployment.account)?;
 
         deployment
             .version_control
-            .register_natives(deployment.contracts(), &version)?;
+            .register_natives(deployment.contracts())?;
 
         // Create the first abstract account in integration environments
         #[cfg(feature = "integration")]
@@ -174,12 +172,12 @@ impl<Chain: CwEnv> Abstract<Chain> {
         Ok(())
     }
 
-    pub fn contracts(&self) -> Vec<&cw_orch::contract::Contract<Chain>> {
+    pub fn contracts(&self) -> Vec<(&cw_orch::contract::Contract<Chain>,String)> {
         vec![
-            self.ans_host.as_instance(),
-            self.version_control.as_instance(),
-            self.account_factory.as_instance(),
-            self.module_factory.as_instance(),
+            (self.ans_host.as_instance(),ans_host::contract::CONTRACT_VERSION.to_string()),
+            (self.version_control.as_instance(),version_control::contract::CONTRACT_VERSION.to_string()),
+            (self.account_factory.as_instance(),account_factory::contract::CONTRACT_VERSION.to_string()),
+            (self.module_factory.as_instance(),module_factory::contract::CONTRACT_VERSION.to_string()),
         ]
     }
 }

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -4,10 +4,7 @@ use crate::{
     get_account_contracts, get_native_contracts, AbstractAccount, AbstractInterfaceError,
     AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VersionControl,
 };
-use abstract_core::{
-    objects::gov_type::GovernanceDetails, ACCOUNT_FACTORY, ANS_HOST, MANAGER, MODULE_FACTORY,
-    PROXY, VERSION_CONTROL,
-};
+use abstract_core::{ACCOUNT_FACTORY, ANS_HOST, MANAGER, MODULE_FACTORY, PROXY, VERSION_CONTROL};
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
 
@@ -77,6 +74,8 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
             .register_natives(deployment.contracts())?;
 
         // Create the first abstract account in integration environments
+        #[cfg(feature = "integration")]
+        use abstract_core::objects::gov_type::GovernanceDetails;
         #[cfg(feature = "integration")]
         deployment
             .account_factory

--- a/packages/abstract-interface/src/native/module_factory.rs
+++ b/packages/abstract-interface/src/native/module_factory.rs
@@ -10,7 +10,6 @@ pub use abstract_core::module_factory::{
 pub struct ModuleFactory<Chain>;
 
 impl<Chain: CwEnv> Uploadable for ModuleFactory<Chain> {
-    #[cfg(feature = "integration")]
     fn wrapper(&self) -> <Mock as TxHandler>::ContractSource {
         Box::new(
             ContractWrapper::new_with_empty(
@@ -43,23 +42,4 @@ impl<Chain: CwEnv> ModuleFactory<Chain> {
         )
         .map_err(Into::into)
     }
-
-    // pub  fn save_init_binaries(&self, mem_addr: String, version_control_addr: String) -> Result<(), crate::AbstractBootError> {
-    //     let msgs = get_adapter_init_msgs(mem_addr,version_control_addr);
-    //     // TODO: Add version management support
-    //     let binaries = msgs
-    //         .iter()
-    //         .map(|(name, msg)| ((name.clone(), "v0.1.0".to_string()), msg.clone()))
-    //         .collect::<Vec<_>>();
-    //     self.0
-    //         .execute(
-    //             &ExecuteMsg::UpdateFactoryBinaryMsgs {
-    //                 to_add: binaries,
-    //                 to_remove: vec![(LIQUIDITY_INTERFACE.to_string(), "v0.1.0".to_string())],
-    //             },
-    //             &vec![],
-    //         )
-    //         ?;
-    //     Ok(())
-    // }
 }

--- a/packages/abstract-interface/src/native/version_control.rs
+++ b/packages/abstract-interface/src/native/version_control.rs
@@ -61,7 +61,10 @@ where
     ) -> Result<(), crate::AbstractInterfaceError> {
         let manager = account.manager.as_instance();
         let manager_module = (
-            ModuleInfo::from_id(&manager.id, ModuleVersion::Version(manager::contract::CONTRACT_VERSION.to_string()))?,
+            ModuleInfo::from_id(
+                &manager.id,
+                ModuleVersion::Version(manager::contract::CONTRACT_VERSION.to_string()),
+            )?,
             ModuleReference::AccountBase(manager.code_id()?),
         );
         self.propose_modules(vec![manager_module])?;
@@ -70,7 +73,10 @@ where
 
         let proxy = account.proxy.as_instance();
         let proxy_module = (
-            ModuleInfo::from_id(&proxy.id, ModuleVersion::Version(proxy::contract::CONTRACT_VERSION.to_string()))?,
+            ModuleInfo::from_id(
+                &proxy.id,
+                ModuleVersion::Version(proxy::contract::CONTRACT_VERSION.to_string()),
+            )?,
             ModuleReference::AccountBase(proxy.code_id()?),
         );
         self.propose_modules(vec![proxy_module])?;
@@ -82,7 +88,7 @@ where
     /// Register account modules
     pub fn register_account_mods(
         &self,
-        apps: Vec<(&Contract<Chain>,VersionString)>,
+        apps: Vec<(&Contract<Chain>, VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
         let to_register = self.contracts_into_module_entries(apps, |c| {
             ModuleReference::AccountBase(c.code_id().unwrap())
@@ -94,7 +100,7 @@ where
     /// Register native modules
     pub fn register_natives(
         &self,
-        natives: Vec<(&Contract<Chain>,VersionString)>,
+        natives: Vec<(&Contract<Chain>, VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
         let to_register = self.contracts_into_module_entries(natives, |c| {
             ModuleReference::Native(c.address().unwrap())
@@ -105,18 +111,17 @@ where
 
     pub fn register_apps(
         &self,
-        apps: Vec<(&Contract<Chain>,VersionString)>,
+        apps: Vec<(&Contract<Chain>, VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        let to_register = self.contracts_into_module_entries(apps, |c| {
-            ModuleReference::App(c.code_id().unwrap())
-        })?;
+        let to_register = self
+            .contracts_into_module_entries(apps, |c| ModuleReference::App(c.code_id().unwrap()))?;
         self.propose_modules(to_register)?;
         Ok(())
     }
 
     pub fn register_adapters(
         &self,
-        adapters: Vec<(&Contract<Chain>,VersionString)>,
+        adapters: Vec<(&Contract<Chain>, VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
         let to_register = self.contracts_into_module_entries(adapters, |c| {
             ModuleReference::Adapter(c.address().unwrap())
@@ -127,7 +132,7 @@ where
 
     pub fn register_standalones(
         &self,
-        standalones: Vec<(&Contract<Chain>,VersionString)>,
+        standalones: Vec<(&Contract<Chain>, VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
         let to_register = self.contracts_into_module_entries(standalones, |c| {
             ModuleReference::Standalone(c.code_id().unwrap())
@@ -138,7 +143,7 @@ where
 
     fn contracts_into_module_entries<RefFn>(
         &self,
-        modules: Vec<(&Contract<Chain>,VersionString)>,
+        modules: Vec<(&Contract<Chain>, VersionString)>,
         ref_fn: RefFn,
     ) -> Result<Vec<(ModuleInfo, ModuleReference)>, crate::AbstractInterfaceError>
     where
@@ -149,7 +154,7 @@ where
             crate::AbstractInterfaceError,
         > = modules
             .iter()
-            .map(|(contract,version)| {
+            .map(|(contract, version)| {
                 Ok((
                     ModuleInfo::from_id(&contract.id, ModuleVersion::Version(version.to_owned()))?,
                     ref_fn(contract),

--- a/packages/abstract-interface/src/native/version_control.rs
+++ b/packages/abstract-interface/src/native/version_control.rs
@@ -15,7 +15,8 @@ use cw_orch::interface;
 #[cfg(feature = "daemon")]
 use cw_orch::prelude::Daemon;
 use cw_orch::prelude::*;
-use semver::Version;
+
+type VersionString = String;
 
 #[interface(InstantiateMsg, ExecuteMsg, QueryMsg, MigrateMsg)]
 pub struct VersionControl<Chain>;
@@ -57,11 +58,10 @@ where
     pub fn register_base(
         &self,
         account: &AbstractAccount<Chain>,
-        version: &str,
     ) -> Result<(), crate::AbstractInterfaceError> {
         let manager = account.manager.as_instance();
         let manager_module = (
-            ModuleInfo::from_id(&manager.id, ModuleVersion::Version(version.to_string()))?,
+            ModuleInfo::from_id(&manager.id, ModuleVersion::Version(manager::contract::CONTRACT_VERSION.to_string()))?,
             ModuleReference::AccountBase(manager.code_id()?),
         );
         self.propose_modules(vec![manager_module])?;
@@ -70,7 +70,7 @@ where
 
         let proxy = account.proxy.as_instance();
         let proxy_module = (
-            ModuleInfo::from_id(&proxy.id, ModuleVersion::Version(version.to_string()))?,
+            ModuleInfo::from_id(&proxy.id, ModuleVersion::Version(proxy::contract::CONTRACT_VERSION.to_string()))?,
             ModuleReference::AccountBase(proxy.code_id()?),
         );
         self.propose_modules(vec![proxy_module])?;
@@ -82,10 +82,9 @@ where
     /// Register account modules
     pub fn register_account_mods(
         &self,
-        apps: Vec<&Contract<Chain>>,
-        version: &Version,
+        apps: Vec<(&Contract<Chain>,VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        let to_register = self.contracts_into_module_entries(apps, version, |c| {
+        let to_register = self.contracts_into_module_entries(apps, |c| {
             ModuleReference::AccountBase(c.code_id().unwrap())
         })?;
         self.propose_modules(to_register)?;
@@ -95,10 +94,9 @@ where
     /// Register native modules
     pub fn register_natives(
         &self,
-        natives: Vec<&Contract<Chain>>,
-        version: &Version,
+        natives: Vec<(&Contract<Chain>,VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        let to_register = self.contracts_into_module_entries(natives, version, |c| {
+        let to_register = self.contracts_into_module_entries(natives, |c| {
             ModuleReference::Native(c.address().unwrap())
         })?;
         self.propose_modules(to_register)?;
@@ -107,10 +105,9 @@ where
 
     pub fn register_apps(
         &self,
-        apps: Vec<&Contract<Chain>>,
-        version: &Version,
+        apps: Vec<(&Contract<Chain>,VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        let to_register = self.contracts_into_module_entries(apps, version, |c| {
+        let to_register = self.contracts_into_module_entries(apps, |c| {
             ModuleReference::App(c.code_id().unwrap())
         })?;
         self.propose_modules(to_register)?;
@@ -119,10 +116,9 @@ where
 
     pub fn register_adapters(
         &self,
-        adapters: Vec<&Contract<Chain>>,
-        version: &Version,
+        adapters: Vec<(&Contract<Chain>,VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        let to_register = self.contracts_into_module_entries(adapters, version, |c| {
+        let to_register = self.contracts_into_module_entries(adapters, |c| {
             ModuleReference::Adapter(c.address().unwrap())
         })?;
         self.propose_modules(to_register)?;
@@ -131,10 +127,9 @@ where
 
     pub fn register_standalones(
         &self,
-        standalones: Vec<&Contract<Chain>>,
-        version: &Version,
+        standalones: Vec<(&Contract<Chain>,VersionString)>,
     ) -> Result<(), crate::AbstractInterfaceError> {
-        let to_register = self.contracts_into_module_entries(standalones, version, |c| {
+        let to_register = self.contracts_into_module_entries(standalones, |c| {
             ModuleReference::Standalone(c.code_id().unwrap())
         })?;
         self.propose_modules(to_register)?;
@@ -143,8 +138,7 @@ where
 
     fn contracts_into_module_entries<RefFn>(
         &self,
-        modules: Vec<&Contract<Chain>>,
-        version: &Version,
+        modules: Vec<(&Contract<Chain>,VersionString)>,
         ref_fn: RefFn,
     ) -> Result<Vec<(ModuleInfo, ModuleReference)>, crate::AbstractInterfaceError>
     where
@@ -155,9 +149,9 @@ where
             crate::AbstractInterfaceError,
         > = modules
             .iter()
-            .map(|contract| {
+            .map(|(contract,version)| {
                 Ok((
-                    ModuleInfo::from_id(&contract.id, ModuleVersion::Version(version.to_string()))?,
+                    ModuleInfo::from_id(&contract.id, ModuleVersion::Version(version.to_owned()))?,
                     ref_fn(contract),
                 ))
             })

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -19,7 +19,9 @@ cw20-base = { workspace = true }
 cw-orch = { workspace = true, features = ["daemon"] }
 abstract-core = { workspace = true, features = ["interface"] }
 
-abstract-interface = { workspace = true, features = ["daemon"], default-features = false }
+abstract-interface = { workspace = true, features = [
+  "daemon",
+], default-features = false }
 tokio = { workspace = true }
 log = "0.4.14"
 anyhow = { workspace = true }


### PR DESCRIPTION
pathes the abstract contract uploads to use the contract's actual versions. This should prevent version conflict between the contract's on-chain version and the version control's version