### PR TITLE
Added the possiblity to store 2 addresses for a liquidity pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,7 @@ protobuf = { version = "2", features = ["with-bytes"] }
 clap = { version = "4.0.32", features = ["derive"] }
 semver = "1.0"
 cw-semver = { version = "1.0" }
-# cw-orch = { version = "0.12", git = "https://github.com/AbstractSDK/cw-orchestrator" }
-cw-orch = { git = "https://github.com/AbstractSDK/cw-orchestrator.git", branch = "debug/artifacts_path" }
+cw-orch = { version = "0.12" }
 tokio = { version = "1.4", features = ["full"] }
 
 ## crates in order of publishing ## see docs/Publishing.md

--- a/packages/abstract-core/src/objects/pool/pool_id.rs
+++ b/packages/abstract-core/src/objects/pool/pool_id.rs
@@ -5,6 +5,7 @@ use std::{fmt, str::FromStr};
 #[cosmwasm_schema::cw_serde]
 #[non_exhaustive]
 pub enum PoolAddressBase<T> {
+    SeparateAddresses { swap: T, liquidity: T },
     Contract(T),
     Id(u64),
 }
@@ -91,6 +92,12 @@ impl From<PoolAddress> for UncheckedPoolAddress {
                 UncheckedPoolAddress::Contract(contract_addr.into())
             }
             PoolAddress::Id(denom) => UncheckedPoolAddress::Id(denom),
+            PoolAddress::SeparateAddresses { swap, liquidity } => {
+                UncheckedPoolAddress::SeparateAddresses {
+                    swap: swap.into(),
+                    liquidity: liquidity.into(),
+                }
+            }
         }
     }
 }
@@ -102,6 +109,12 @@ impl From<&PoolAddress> for UncheckedPoolAddress {
                 UncheckedPoolAddress::Contract(contract_addr.into())
             }
             PoolAddress::Id(denom) => UncheckedPoolAddress::Id(*denom),
+            PoolAddress::SeparateAddresses { swap, liquidity } => {
+                UncheckedPoolAddress::SeparateAddresses {
+                    swap: swap.into(),
+                    liquidity: liquidity.into(),
+                }
+            }
         }
     }
 }
@@ -135,6 +148,12 @@ impl UncheckedPoolAddress {
                 PoolAddress::Contract(api.addr_validate(contract_addr)?)
             }
             UncheckedPoolAddress::Id(pool_id) => PoolAddress::Id(*pool_id),
+            UncheckedPoolAddress::SeparateAddresses { swap, liquidity } => {
+                PoolAddress::SeparateAddresses {
+                    swap: api.addr_validate(swap)?,
+                    liquidity: api.addr_validate(liquidity)?,
+                }
+            }
         })
     }
 }
@@ -144,6 +163,9 @@ impl fmt::Display for PoolAddress {
         match self {
             PoolAddress::Contract(contract_addr) => write!(f, "contract:{contract_addr}"),
             PoolAddress::Id(pool_id) => write!(f, "id:{pool_id}"),
+            PoolAddress::SeparateAddresses { swap, liquidity } => {
+                write!(f, "swap:{swap}, pair: {liquidity}")
+            }
         }
     }
 }


### PR DESCRIPTION
This PR aims at integrating a new way of interacting with liquidity pools. 
For Kujira based liquidity pools there are 2 addresses to interact with : 
1. The address for swapping an asset
2. The address for providing liquidity to a pool