### PR TITLE
Add ModuleActionResponse variant to Proxy

### DIFF
--- a/contracts/account/manager/tests/adapters.rs
+++ b/contracts/account/manager/tests/adapters.rs
@@ -6,7 +6,10 @@ use abstract_core::objects::module::{ModuleInfo, ModuleVersion};
 use abstract_core::{adapter::BaseQueryMsgFns, *};
 use abstract_interface::*;
 use abstract_testing::prelude::{OWNER, TEST_ACCOUNT_ID, TEST_MODULE_ID, TEST_VERSION};
-use common::{create_default_account, init_mock_adapter, AResult, TEST_COIN};
+use common::{
+    create_default_account, init_mock_adapter, install_adapter, uninstall_module, AResult,
+    TEST_COIN,
+};
 use cosmwasm_std::{Addr, Coin, Empty};
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
@@ -14,19 +17,6 @@ use cw_orch::prelude::*;
 use speculoos::{assert_that, result::ResultAssertions, string::StrAssertions};
 
 use crate::common::mock_modules::{BootMockAdapter1V1, BootMockAdapter1V2, V1, V2};
-
-fn install_adapter(manager: &Manager<Mock>, adapter_id: &str) -> AResult {
-    manager
-        .install_module(adapter_id, &Empty {})
-        .map_err(Into::into)
-}
-
-pub(crate) fn uninstall_module(manager: &Manager<Mock>, module_id: &str) -> AResult {
-    manager
-        .uninstall_module(module_id.to_string())
-        .map_err(Into::<CwOrchError>::into)?;
-    Ok(())
-}
 
 #[test]
 fn installing_one_adapter_should_succeed() -> AResult {

--- a/contracts/account/manager/tests/common/mod.rs
+++ b/contracts/account/manager/tests/common/mod.rs
@@ -12,7 +12,8 @@ use abstract_core::version_control::AccountBase;
 use abstract_core::{objects::gov_type::GovernanceDetails, PROXY};
 use abstract_core::{ACCOUNT_FACTORY, ANS_HOST, MANAGER, MODULE_FACTORY, VERSION_CONTROL};
 use abstract_interface::{
-    Abstract, AccountFactory, AnsHost, Manager, ModuleFactory, Proxy, VCExecFns, VersionControl,
+    Abstract, AccountFactory, AnsHost, Manager, ManagerExecFns, ModuleFactory, Proxy, VCExecFns,
+    VersionControl,
 };
 use abstract_interface::{AbstractAccount, AdapterDeployer};
 use cosmwasm_std::Addr;
@@ -46,4 +47,17 @@ pub(crate) fn init_mock_adapter(
         .parse()?;
     staking_adapter.deploy(version, MockInitMsg)?;
     Ok(staking_adapter)
+}
+
+pub fn install_adapter(manager: &Manager<Mock>, adapter_id: &str) -> AResult {
+    manager
+        .install_module(adapter_id, &Empty {})
+        .map_err(Into::into)
+}
+
+pub fn uninstall_module(manager: &Manager<Mock>, module_id: &str) -> AResult {
+    manager
+        .uninstall_module(module_id.to_string())
+        .map_err(Into::<CwOrchError>::into)?;
+    Ok(())
 }

--- a/contracts/account/manager/tests/proxy.rs
+++ b/contracts/account/manager/tests/proxy.rs
@@ -1,10 +1,12 @@
 mod common;
+use abstract_adapter::mock::MockExecMsg;
+use abstract_core::adapter::AdapterRequestMsg;
 use abstract_core::{manager::ManagerModuleInfo, PROXY};
 use abstract_interface::*;
 use abstract_manager::contract::CONTRACT_VERSION;
-use abstract_testing::prelude::TEST_ACCOUNT_ID;
-use common::{create_default_account, AResult, TEST_COIN};
-use cosmwasm_std::{Addr, Coin, CosmosMsg};
+use abstract_testing::prelude::{TEST_ACCOUNT_ID, TEST_MODULE_ID};
+use common::{create_default_account, init_mock_adapter, install_adapter, AResult, TEST_COIN};
+use cosmwasm_std::{wasm_execute, Addr, Coin, CosmosMsg};
 use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
 use speculoos::prelude::*;
@@ -77,6 +79,86 @@ fn exec_through_manager() -> AResult {
         .wrap()
         .query_all_balances(account.proxy.address()?)?;
     assert_that!(proxy_balance).is_equal_to(vec![Coin::new(100_000 - 10_000, TEST_COIN)]);
+
+    Ok(())
+}
+
+#[test]
+fn default_without_response_data() -> AResult {
+    let sender = Addr::unchecked(common::OWNER);
+    let chain = Mock::new(&sender);
+    let deployment = Abstract::deploy_on(chain.clone(), Empty {})?;
+    let account = create_default_account(&deployment.account_factory)?;
+    let _staking_adapter_one = init_mock_adapter(chain.clone(), &deployment, None)?;
+
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
+
+    chain.set_balance(
+        &account.proxy.address()?,
+        vec![Coin::new(100_000, TEST_COIN)],
+    )?;
+
+    let resp = account.manager.execute_on_module(
+        TEST_MODULE_ID,
+        Into::<abstract_core::adapter::ExecuteMsg<MockExecMsg>>::into(MockExecMsg),
+    )?;
+    assert_that!(resp.data).is_none();
+
+    Ok(())
+}
+
+#[test]
+fn with_response_data() -> AResult {
+    let sender = Addr::unchecked(common::OWNER);
+    let chain = Mock::new(&sender);
+    let deployment = Abstract::deploy_on(chain.clone(), Empty {})?;
+    let account = create_default_account(&deployment.account_factory)?;
+    let staking_adapter = init_mock_adapter(chain.clone(), &deployment, None)?;
+
+    install_adapter(&account.manager, TEST_MODULE_ID)?;
+
+    staking_adapter
+        .call_as(&account.manager.address()?)
+        .execute(
+            &abstract_core::adapter::ExecuteMsg::<MockExecMsg, Empty>::Base(
+                abstract_core::adapter::BaseExecuteMsg::UpdateAuthorizedAddresses {
+                    to_add: vec![account.proxy.addr_str()?],
+                    to_remove: vec![],
+                },
+            ),
+            None,
+        )?;
+
+    chain.set_balance(
+        &account.proxy.address()?,
+        vec![Coin::new(100_000, TEST_COIN)],
+    )?;
+
+    let adapter_addr = account
+        .manager
+        .module_info(TEST_MODULE_ID)?
+        .expect("test module installed");
+    // proxy should be final executor because of the reply
+    let resp = account.manager.exec_on_module(
+        cosmwasm_std::to_binary(&abstract_core::proxy::ExecuteMsg::ModuleActionResponse {
+            // execute a message on the adapter, which sets some data in its response
+            msg: wasm_execute(
+                adapter_addr.address,
+                &abstract_core::adapter::ExecuteMsg::<MockExecMsg, Empty>::Module(
+                    AdapterRequestMsg {
+                        proxy_address: Some(account.proxy.addr_str()?),
+                        request: MockExecMsg,
+                    },
+                ),
+                vec![],
+            )?
+            .into(),
+        })?,
+        PROXY.to_string(),
+    )?;
+
+    let response_data_attr_present = resp.event_attr_value("wasm-abstract", "response_data")?;
+    assert_that!(response_data_attr_present).is_equal_to("true".to_string());
 
     Ok(())
 }

--- a/contracts/account/proxy/src/contract.rs
+++ b/contracts/account/proxy/src/contract.rs
@@ -1,6 +1,6 @@
-use crate::commands::*;
 use crate::error::ProxyError;
 use crate::queries::*;
+use crate::{commands::*, reply};
 use abstract_core::objects::module_version::assert_contract_upgrade;
 use abstract_core::objects::oracle::Oracle;
 use abstract_macros::abstract_response;
@@ -15,10 +15,13 @@ use abstract_sdk::{
     },
     feature_objects::AnsHost,
 };
-use cosmwasm_std::{to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Response};
+use cosmwasm_std::{
+    to_binary, Binary, Deps, DepsMut, Env, MessageInfo, Reply, Response, SubMsgResult,
+};
 use semver::Version;
 
 pub const CONTRACT_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub(crate) const RESPONSE_REPLY_ID: u64 = 1;
 
 #[abstract_response(PROXY)]
 pub struct ProxyResponse;
@@ -57,6 +60,7 @@ pub fn instantiate(
 pub fn execute(deps: DepsMut, _env: Env, info: MessageInfo, msg: ExecuteMsg) -> ProxyResult {
     match msg {
         ExecuteMsg::ModuleAction { msgs } => execute_module_action(deps, info, msgs),
+        ExecuteMsg::ModuleActionResponse { msg } => execute_module_action_response(deps, info, msg),
         ExecuteMsg::IbcAction { msgs } => execute_ibc_action(deps, info, msgs),
         ExecuteMsg::SetAdmin { admin } => set_admin(deps, info, &admin),
         ExecuteMsg::AddModule { module } => add_module(deps, info, module),
@@ -99,6 +103,18 @@ pub fn query(deps: Deps, env: Env, msg: QueryMsg) -> ProxyResult<Binary> {
         QueryMsg::BaseAsset {} => to_binary(&query_base_asset(deps)?),
     }
     .map_err(Into::into)
+}
+
+/// This just stores the result for future query
+#[cfg_attr(feature = "export", cosmwasm_std::entry_point)]
+pub fn reply(_deps: DepsMut, _env: Env, msg: Reply) -> ProxyResult {
+    match msg {
+        Reply {
+            id: RESPONSE_REPLY_ID,
+            result: SubMsgResult::Ok(result),
+        } => reply::forward_response_data(result),
+        _ => Err(ProxyError::UnexpectedReply {}),
+    }
 }
 
 #[cfg(test)]

--- a/contracts/account/proxy/src/error.rs
+++ b/contracts/account/proxy/src/error.rs
@@ -43,7 +43,7 @@ pub enum ProxyError {
     BadUpdate(String),
 
     #[error(
-        "Treasury balance too low, {} requested but it only has {}",
+        "Account balance too low, {} requested but it only has {}",
         requested,
         balance
     )]
@@ -51,4 +51,7 @@ pub enum ProxyError {
         balance: Uint128,
         requested: Uint128,
     },
+
+    #[error("Contract got an unexpected Reply")]
+    UnexpectedReply(),
 }

--- a/contracts/account/proxy/src/lib.rs
+++ b/contracts/account/proxy/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 pub mod contract;
 mod error;
 mod queries;
+pub mod reply;
 
 #[cfg(test)]
 mod test_common {

--- a/contracts/account/proxy/src/reply.rs
+++ b/contracts/account/proxy/src/reply.rs
@@ -1,0 +1,20 @@
+use cosmwasm_std::SubMsgResponse;
+
+use crate::contract::{ProxyResponse, ProxyResult};
+
+/// Add the message's data to the response
+pub fn forward_response_data(result: SubMsgResponse) -> ProxyResult {
+    // log if none
+    let attr = if result.data.is_none() {
+        ("response_data", "false")
+    } else {
+        ("response_data", "true")
+    };
+
+    let mut resp = ProxyResponse::new("forward_response_data_reply", vec![attr]);
+
+    // set the data
+    resp.data = result.data;
+
+    Ok(resp)
+}

--- a/packages/abstract-core/src/core/proxy.rs
+++ b/packages/abstract-core/src/core/proxy.rs
@@ -54,6 +54,8 @@ pub enum ExecuteMsg {
     SetAdmin { admin: String },
     /// Executes the provided messages if sender is whitelisted
     ModuleAction { msgs: Vec<CosmosMsg<Empty>> },
+    /// Execute a message and forward the Response data
+    ModuleActionResponse { msg: CosmosMsg<Empty> },
     /// Execute IBC action on Client
     IbcAction { msgs: Vec<IbcClientMsg> },
     /// Adds the provided address to whitelisted dapps

--- a/packages/abstract-interface/src/account/manager.rs
+++ b/packages/abstract-interface/src/account/manager.rs
@@ -84,15 +84,16 @@ impl<Chain: CwEnv> Manager<Chain> {
         &self,
         module: &str,
         msg: impl Serialize,
-    ) -> Result<(), crate::AbstractInterfaceError> {
+    ) -> Result<<Chain as cw_orch::prelude::TxHandler>::Response, crate::AbstractInterfaceError>
+    {
         self.execute(
             &ExecuteMsg::ExecOnModule {
                 module_id: module.into(),
                 exec_msg: to_binary(&msg).unwrap(),
             },
             None,
-        )?;
-        Ok(())
+        )
+        .map_err(Into::into)
     }
 
     pub fn update_adapter_authorized_addresses(

--- a/packages/abstract-interface/src/account/proxy.rs
+++ b/packages/abstract-interface/src/account/proxy.rs
@@ -20,7 +20,8 @@ impl<Chain: CwEnv> Uploadable for Proxy<Chain> {
                 ::proxy::contract::instantiate,
                 ::proxy::contract::query,
             )
-            .with_migrate(::proxy::contract::migrate),
+            .with_migrate(::proxy::contract::migrate)
+            .with_reply(::proxy::contract::reply),
         )
     }
     fn wasm(&self) -> WasmPath {


### PR DESCRIPTION
Adds a new endpoint that supports response data forwarding through a reply in the proxy contract. This allows developers to execute actions on a contrac and retrieve the result data even when proxied through the account