### PR TITLE
Allow Loading accoutns from chain directly

### DIFF
--- a/contracts/native/account-factory/tests/create_account.rs
+++ b/contracts/native/account-factory/tests/create_account.rs
@@ -155,7 +155,7 @@ fn create_two_account_s() -> AResult {
 fn sender_is_not_admin_monarchy() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let chain = Mock::new(&sender);
-    let deployment = Abstract::deploy_on(chain.clone(), Empty {})?;
+    let deployment = Abstract::deploy_on(chain, Empty {})?;
 
     let factory = &deployment.account_factory;
     let version_control = &deployment.version_control;
@@ -173,7 +173,7 @@ fn sender_is_not_admin_monarchy() -> AResult {
 
     let account = version_control.account_base(TEST_ACCOUNT_ID)?.account_base;
 
-    let account_1 = AbstractAccount::new(chain, Some(TEST_ACCOUNT_ID));
+    let account_1 = AbstractAccount::new(&deployment, Some(TEST_ACCOUNT_ID));
     assert_that!(AccountBase {
         manager: account_1.manager.address()?,
         proxy: account_1.proxy.address()?,
@@ -202,7 +202,7 @@ fn sender_is_not_admin_monarchy() -> AResult {
 fn sender_is_not_admin_external() -> AResult {
     let sender = Addr::unchecked(common::OWNER);
     let chain = Mock::new(&sender);
-    let deployment = Abstract::deploy_on(chain.clone(), Empty {})?;
+    let deployment = Abstract::deploy_on(chain, Empty {})?;
 
     let factory = &deployment.account_factory;
     let version_control = &deployment.version_control;
@@ -216,7 +216,7 @@ fn sender_is_not_admin_external() -> AResult {
         Some(String::from("http://account_link_of_at_least_11_char")),
     )?;
 
-    let account = AbstractAccount::new(chain, Some(TEST_ACCOUNT_ID));
+    let account = AbstractAccount::new(&deployment, Some(TEST_ACCOUNT_ID));
     let account_config = account.manager.config()?;
 
     assert_that!(account_config).is_equal_to(abstract_core::manager::ConfigResponse {

--- a/packages/abstract-interface/src/account/mod.rs
+++ b/packages/abstract-interface/src/account/mod.rs
@@ -45,8 +45,8 @@ impl<Chain: CwEnv> AbstractAccount<Chain> {
 }
 
 impl<Chain: CwEnv> AbstractAccount<Chain> {
-    pub fn new(chain: Chain, account_id: Option<AccountId>) -> Self {
-        let (manager, proxy) = get_account_contracts(chain, account_id);
+    pub fn new(abs: &Abstract<Chain>, account_id: Option<AccountId>) -> Self {
+        let (manager, proxy) = get_account_contracts(&abs.version_control, account_id);
         Self { manager, proxy }
     }
 

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -118,8 +118,8 @@ impl<Chain: CwEnv> Deploy<Chain> for Abstract<Chain> {
 impl<Chain: CwEnv> Abstract<Chain> {
     pub fn new(chain: Chain) -> Self {
         let (ans_host, account_factory, version_control, module_factory, _ibc_client) =
-            get_native_contracts(chain.clone());
-        let (manager, proxy) = get_account_contracts(chain, None);
+            get_native_contracts(chain);
+        let (manager, proxy) = get_account_contracts(&version_control, None);
         Self {
             account: AbstractAccount { manager, proxy },
             ans_host,

--- a/packages/abstract-interface/src/interfaces.rs
+++ b/packages/abstract-interface/src/interfaces.rs
@@ -1,6 +1,4 @@
-use crate::{
-    AccountFactory, AnsHost, IbcClient, Manager, ModuleFactory, Proxy, VersionControl,
-};
+use crate::{AccountFactory, AnsHost, IbcClient, Manager, ModuleFactory, Proxy, VersionControl};
 use abstract_core::{
     objects::AccountId, ACCOUNT_FACTORY, ANS_HOST, IBC_CLIENT, MANAGER, MODULE_FACTORY, PROXY,
     VERSION_CONTROL,
@@ -42,7 +40,6 @@ pub fn get_account_contracts<Chain: CwEnv>(
 where
     <Chain as cw_orch::environment::TxHandler>::Response: IndexResponse,
 {
-
     let chain = version_control.get_chain().clone();
     if let Some(account_id) = account_id {
         let account_base = version_control.get_account(account_id).unwrap();

--- a/packages/abstract-interface/src/interfaces.rs
+++ b/packages/abstract-interface/src/interfaces.rs
@@ -1,8 +1,11 @@
-use crate::{AccountFactory, AnsHost, IbcClient, Manager, ModuleFactory, Proxy, VersionControl};
+use crate::{
+    Abstract, AccountFactory, AnsHost, IbcClient, Manager, ModuleFactory, Proxy, VersionControl,
+};
 use abstract_core::{
     objects::AccountId, ACCOUNT_FACTORY, ANS_HOST, IBC_CLIENT, MANAGER, MODULE_FACTORY, PROXY,
     VERSION_CONTROL,
 };
+use cw_orch::deploy::Deploy;
 use cw_orch::prelude::*;
 
 #[allow(clippy::type_complexity)]
@@ -40,8 +43,8 @@ where
     <Chain as cw_orch::environment::TxHandler>::Response: IndexResponse,
 {
     if let Some(account_id) = account_id {
-        let version_control = VersionControl::new(VERSION_CONTROL, chain.clone());
-        let account_base = version_control.get_account(account_id).unwrap();
+        let abs = Abstract::load_from(chain.clone()).unwrap();
+        let account_base = abs.version_control.get_account(account_id).unwrap();
         chain.state().set_address(MANAGER, &account_base.manager);
         chain.state().set_address(PROXY, &account_base.proxy);
         let manager = Manager::new(MANAGER, chain.clone());

--- a/packages/abstract-interface/src/interfaces.rs
+++ b/packages/abstract-interface/src/interfaces.rs
@@ -1,11 +1,11 @@
 use crate::{
-    Abstract, AccountFactory, AnsHost, IbcClient, Manager, ModuleFactory, Proxy, VersionControl,
+    AccountFactory, AnsHost, IbcClient, Manager, ModuleFactory, Proxy, VersionControl,
 };
 use abstract_core::{
     objects::AccountId, ACCOUNT_FACTORY, ANS_HOST, IBC_CLIENT, MANAGER, MODULE_FACTORY, PROXY,
     VERSION_CONTROL,
 };
-use cw_orch::deploy::Deploy;
+
 use cw_orch::prelude::*;
 
 #[allow(clippy::type_complexity)]
@@ -36,15 +36,16 @@ where
 }
 
 pub fn get_account_contracts<Chain: CwEnv>(
-    chain: Chain,
+    version_control: &VersionControl<Chain>,
     account_id: Option<AccountId>,
 ) -> (Manager<Chain>, Proxy<Chain>)
 where
     <Chain as cw_orch::environment::TxHandler>::Response: IndexResponse,
 {
+
+    let chain = version_control.get_chain().clone();
     if let Some(account_id) = account_id {
-        let abs = Abstract::load_from(chain.clone()).unwrap();
-        let account_base = abs.version_control.get_account(account_id).unwrap();
+        let account_base = version_control.get_account(account_id).unwrap();
         chain.state().set_address(MANAGER, &account_base.manager);
         chain.state().set_address(PROXY, &account_base.proxy);
         let manager = Manager::new(MANAGER, chain.clone());


### PR DESCRIPTION
This PR aims at allowing loading abstract accounts direcly from chain, instead of having to register the version control first