### PR TITLE
Add ability to update module code-id in testing setting.

### DIFF
--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -43,7 +43,7 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
     cw2::set_contract_version(deps.storage, VERSION_CONTROL, CONTRACT_VERSION)?;
 
     let InstantiateMsg {
-        allow_direct_module_registration,
+        allow_direct_module_registration_and_updates,
         namespace_limit,
         namespace_registration_fee,
     } = msg;
@@ -51,7 +51,8 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
     CONFIG.save(
         deps.storage,
         &Config {
-            allow_direct_module_registration: allow_direct_module_registration.unwrap_or(false),
+            allow_direct_module_registration_and_updates:
+                allow_direct_module_registration_and_updates.unwrap_or(false),
             namespace_limit,
             namespace_registration_fee: namespace_registration_fee.unwrap_or(Coin {
                 denom: "none".to_string(),
@@ -99,13 +100,13 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
             account_base: base,
         } => add_account(deps, info, account_id, base),
         ExecuteMsg::UpdateConfig {
-            allow_direct_module_registration,
+            allow_direct_module_registration_and_updates,
             namespace_limit,
             namespace_registration_fee,
         } => update_config(
             deps,
             info,
-            allow_direct_module_registration,
+            allow_direct_module_registration_and_updates,
             namespace_limit,
             namespace_registration_fee,
         ),

--- a/contracts/native/version-control/src/lib.rs
+++ b/contracts/native/version-control/src/lib.rs
@@ -20,7 +20,7 @@ mod testing {
             mock_env(),
             info,
             version_control::InstantiateMsg {
-                allow_direct_module_registration: Some(true),
+                allow_direct_module_registration_and_updates: Some(true),
                 namespace_limit: 10,
                 namespace_registration_fee: None,
             },

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -349,7 +349,7 @@ mod test {
             mock_env(),
             info,
             InstantiateMsg {
-                allow_direct_module_registration: Some(true),
+                allow_direct_module_registration_and_updates: Some(true),
                 namespace_limit: 10,
                 namespace_registration_fee: None,
             },

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -13,7 +13,7 @@ pub type ModuleMapEntry = (ModuleInfo, ModuleReference);
 /// Contains configuration info of version control.
 #[cosmwasm_schema::cw_serde]
 pub struct Config {
-    pub allow_direct_module_registration: bool,
+    pub allow_direct_module_registration_and_updates: bool,
     pub namespace_limit: u32,
     pub namespace_registration_fee: cosmwasm_std::Coin,
 }
@@ -92,7 +92,10 @@ pub struct AccountBase {
 /// Version Control Instantiate Msg
 #[cosmwasm_schema::cw_serde]
 pub struct InstantiateMsg {
-    pub allow_direct_module_registration: Option<bool>,
+    /// allows users to directly register modules without going through approval
+    /// Also allows them to change the module reference of an existing module
+    /// SHOULD ONLY BE `true` FOR TESTING
+    pub allow_direct_module_registration_and_updates: Option<bool>,
     pub namespace_limit: u32,
     pub namespace_registration_fee: Option<Coin>,
 }
@@ -144,7 +147,7 @@ pub enum ExecuteMsg {
     /// 1. Whether the contract allows direct module registration
     /// 2. the number of namespaces an Account can claim
     UpdateConfig {
-        allow_direct_module_registration: Option<bool>,
+        allow_direct_module_registration_and_updates: Option<bool>,
         namespace_limit: Option<u32>,
         namespace_registration_fee: Option<Coin>,
     },

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -140,7 +140,7 @@ impl<Chain: CwEnv> Abstract<Chain> {
 
         self.version_control.instantiate(
             &abstract_core::version_control::InstantiateMsg {
-                allow_direct_module_registration: Some(true),
+                allow_direct_module_registration_and_updates: Some(true),
                 namespace_limit: 1,
                 namespace_registration_fee: None,
             },


### PR DESCRIPTION
Adds the ability to replace a module's details when the contract is configured to allow it. This should make it easier to re-deploy and test modules on testnets. The setting should be turned off for mainnet. 
