### PR TITLE
Restrict number of namespaces to one

### DIFF
--- a/contracts/account/manager/tests/adapters.rs
+++ b/contracts/account/manager/tests/adapters.rs
@@ -219,7 +219,7 @@ fn reinstalling_new_version_should_install_latest() -> AResult {
     let account = create_default_account(&deployment.account_factory)?;
     deployment
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec!["tester".to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, "tester".to_string())?;
 
     let adapter1 = BootMockAdapter1V1::new_test(chain.clone());
     adapter1.deploy(V1.parse().unwrap(), MockInitMsg).unwrap();
@@ -339,7 +339,7 @@ fn installing_specific_version_should_install_expected() -> AResult {
     let account = create_default_account(&deployment.account_factory)?;
     deployment
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec!["tester".to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, "tester".to_string())?;
 
     let adapter1 = BootMockAdapter1V1::new_test(chain.clone());
     adapter1.deploy(V1.parse().unwrap(), MockInitMsg).unwrap();

--- a/contracts/account/manager/tests/common/mod.rs
+++ b/contracts/account/manager/tests/common/mod.rs
@@ -43,7 +43,7 @@ pub(crate) fn init_mock_adapter(
 ) -> anyhow::Result<BootMockAdapter<Mock>> {
     deployment
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec!["tester".to_string()]);
+        .claim_namespace(TEST_ACCOUNT_ID, "tester".to_string());
     let mut staking_adapter = BootMockAdapter::new(TEST_MODULE_ID, chain);
     let version: Version = version
         .unwrap_or_else(|| CONTRACT_VERSION.to_string())

--- a/contracts/account/manager/tests/upgrades.rs
+++ b/contracts/account/manager/tests/upgrades.rs
@@ -48,7 +48,7 @@ fn install_app_successful() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, TEST_NAMESPACE.to_string())?;
     deploy_modules(&chain);
 
     // dependency for mock_adapter1 not met
@@ -87,7 +87,7 @@ fn install_app_versions_not_met() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, TEST_NAMESPACE.to_string())?;
     deploy_modules(&chain);
 
     // install adapter 2
@@ -114,7 +114,7 @@ fn upgrade_app() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, TEST_NAMESPACE.to_string())?;
     deploy_modules(&chain);
 
     // install adapter 1
@@ -284,7 +284,7 @@ fn uninstall_modules() -> AResult {
     let AbstractAccount { manager, proxy: _ } = &account;
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, TEST_NAMESPACE.to_string())?;
     deploy_modules(&chain);
 
     let adapter1 = install_module_version(manager, &abstr, adapter_1::MOCK_ADAPTER_ID, V1)?;
@@ -319,7 +319,7 @@ fn update_adapter_with_authorized_addrs() -> AResult {
     let AbstractAccount { manager, proxy } = &account;
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, TEST_NAMESPACE.to_string())?;
     deploy_modules(&chain);
 
     // install adapter 1
@@ -369,7 +369,7 @@ fn upgrade_manager_last() -> AResult {
 
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
     deploy_modules(&chain);
 
     // install adapter 1
@@ -431,7 +431,7 @@ fn no_duplicate_migrations() -> AResult {
 
     abstr
         .version_control
-        .claim_namespaces(TEST_ACCOUNT_ID, vec![TEST_NAMESPACE.to_string()])?;
+        .claim_namespace(TEST_ACCOUNT_ID, TEST_NAMESPACE.to_string())?;
     deploy_modules(&chain);
 
     // Install adapter 1

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -252,11 +252,11 @@ pub fn set_module_monetization(
 
 /// Claim namespaces
 /// Only the Account Owner can do this
-pub fn claim_namespaces(
+pub fn claim_namespace(
     deps: DepsMut,
     msg_info: MessageInfo,
     account_id: AccountId,
-    namespaces_to_claim: Vec<String>,
+    namespace_to_claim: String,
 ) -> VCResult {
     // verify account owner
     let account_base = ACCOUNT_ADDRESSES.load(deps.storage, account_id)?;
@@ -268,60 +268,55 @@ pub fn claim_namespaces(
         });
     }
 
-    let Config {
-        namespace_limit: namespaces_limit,
-        namespace_registration_fee: fee,
-        ..
-    } = CONFIG.load(deps.storage)?;
-    let limit = namespaces_limit as usize;
-    let existing_namespace_count = namespaces_info()
+    // check if the account already has a namespace
+    let has_namespace = namespaces_info()
         .idx
         .account_id
         .prefix(account_id)
         .range(deps.storage, None, None, Order::Ascending)
-        .count();
-    if existing_namespace_count + namespaces_to_claim.len() > limit {
+        .take(1)
+        .count()
+        == 1;
+    if has_namespace {
         return Err(VCError::ExceedsNamespaceLimit {
-            limit,
-            current: existing_namespace_count,
+            limit: 1,
+            current: 1,
         });
     }
-    if namespaces_to_claim.is_empty() {
-        // Nothing to do if there is no namespace to claim
-        return Err(VCError::NoAction);
-    }
 
-    let nb_namespaces: u128 = namespaces_to_claim.len().try_into().unwrap();
-    let fee_to_charge = FixedFee::new(&fee)
-        .quantity(nb_namespaces)
-        .assert_payment(&msg_info)?;
+    let Config {
+        namespace_registration_fee: fee,
+        ..
+    } = CONFIG.load(deps.storage)?;
 
     let mut fee_messages = vec![];
-    if !fee_to_charge.amount.is_zero() {
+
+    if !fee.amount.is_zero() {
+        // assert it is paid
+        FixedFee::new(&fee).assert_payment(&msg_info)?;
+
         // We transfer the namespace fee if necessary
         let admin_account = ACCOUNT_ADDRESSES.load(deps.storage, 0)?;
         fee_messages.push(CosmosMsg::Bank(BankMsg::Send {
             to_address: admin_account.proxy.to_string(),
-            amount: msg_info.funds, // No funds should be left on the contract. We ensure that here
+            amount: msg_info.funds, //
         }));
     }
 
-    for namespace in namespaces_to_claim.iter() {
-        let namespace = Namespace::try_from(namespace)?;
-        if let Some(id) = namespaces_info().may_load(deps.storage, &namespace)? {
-            return Err(VCError::NamespaceOccupied {
-                namespace: namespace.to_string(),
-                id,
-            });
-        }
-        namespaces_info().save(deps.storage, &namespace, &account_id)?;
+    let namespace = Namespace::try_from(&namespace_to_claim)?;
+    if let Some(id) = namespaces_info().may_load(deps.storage, &namespace)? {
+        return Err(VCError::NamespaceOccupied {
+            namespace: namespace.to_string(),
+            id,
+        });
     }
+    namespaces_info().save(deps.storage, &namespace, &account_id)?;
 
     Ok(VcResponse::new(
-        "claim_namespaces",
+        "claim_namespace",
         vec![
             ("account_id", &account_id.to_string()),
-            ("namespaces", &namespaces_to_claim.join(",")),
+            ("namespaces", &namespace_to_claim),
         ],
     )
     .add_messages(fee_messages))
@@ -379,29 +374,12 @@ pub fn update_config(
     deps: DepsMut,
     info: MessageInfo,
     allow_direct_module_registration: Option<bool>,
-    namespace_limit: Option<u32>,
     namespace_registration_fee: Option<Coin>,
 ) -> VCResult {
     cw_ownable::assert_owner(deps.storage, &info.sender)?;
     let mut config = CONFIG.load(deps.storage)?;
 
     let mut attributes = vec![];
-
-    if let Some(new_limit) = namespace_limit {
-        let previous_limit = config.namespace_limit;
-        ensure!(
-            new_limit > previous_limit,
-            VCError::DecreaseNamespaceLimit {
-                limit: new_limit,
-                current: previous_limit,
-            }
-        );
-        config.namespace_limit = new_limit;
-        attributes.extend(vec![
-            ("previous_namespace_limit", previous_limit.to_string()),
-            ("namespace_limit", new_limit.to_string()),
-        ])
-    }
 
     if let Some(allow) = allow_direct_module_registration {
         let previous_allow = config.allow_direct_module_registration;
@@ -538,7 +516,6 @@ mod test {
             info,
             InstantiateMsg {
                 allow_direct_module_registration: Some(true),
-                namespace_limit: 10,
                 namespace_registration_fee: None,
             },
         )?;
@@ -559,7 +536,6 @@ mod test {
             admin_info,
             InstantiateMsg {
                 allow_direct_module_registration: Some(direct_registration),
-                namespace_limit: 10,
                 namespace_registration_fee: None,
             },
         )?;
@@ -580,6 +556,22 @@ mod test {
                 },
             },
         )
+    }
+
+    fn create_second_account(deps: DepsMut<'_>) {
+        // create second account
+        execute_as(
+            deps,
+            TEST_ACCOUNT_FACTORY,
+            ExecuteMsg::AddAccount {
+                account_id: 2,
+                account_base: AccountBase {
+                    manager: Addr::unchecked(TEST_MANAGER),
+                    proxy: Addr::unchecked(TEST_PROXY),
+                },
+            },
+        )
+        .unwrap();
     }
 
     fn execute_as(deps: DepsMut, sender: &str, msg: ExecuteMsg) -> VCResult {
@@ -681,10 +673,10 @@ mod test {
         }
     }
 
-    mod claim_namespaces {
+    mod claim_namespace {
         use super::*;
         use abstract_core::{objects, AbstractError};
-        use cosmwasm_std::{coins, BankMsg, CosmosMsg, SubMsg, Uint128};
+        use cosmwasm_std::{coins, BankMsg, CosmosMsg, SubMsg};
 
         use objects::ABSTRACT_ACCOUNT_ID;
 
@@ -694,17 +686,27 @@ mod test {
             deps.querier = mock_manager_querier().build();
             mock_init_with_account(deps.as_mut(), true)?;
             let new_namespace1 = Namespace::new("namespace1").unwrap();
-            let new_namespace2 = Namespace::new("namespace2").unwrap();
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+                namespace: new_namespace1.to_string(),
             };
             let res = execute_as(deps.as_mut(), TEST_OWNER, msg);
             assert_that!(&res).is_ok();
+
+            create_second_account(deps.as_mut());
+
+            let new_namespace2 = Namespace::new("namespace2").unwrap();
+            let msg = ExecuteMsg::ClaimNamespace {
+                account_id: 2,
+                namespace: new_namespace2.to_string(),
+            };
+            let res = execute_as(deps.as_mut(), TEST_OWNER, msg);
+            assert_that!(&res).is_ok();
+
             let account_id = namespaces_info().load(&deps.storage, &new_namespace1)?;
             assert_that!(account_id).is_equal_to(TEST_ACCOUNT_ID);
             let account_id = namespaces_info().load(&deps.storage, &new_namespace2)?;
-            assert_that!(account_id).is_equal_to(TEST_ACCOUNT_ID);
+            assert_that!(account_id).is_equal_to(2);
             Ok(())
         }
 
@@ -724,7 +726,6 @@ mod test {
                 deps.as_mut(),
                 ExecuteMsg::UpdateConfig {
                     allow_direct_module_registration: None,
-                    namespace_limit: None,
                     namespace_registration_fee: Some(one_namespace_fee.clone()),
                 },
             )
@@ -746,10 +747,9 @@ mod test {
             .unwrap();
 
             let new_namespace1 = Namespace::new("namespace1").unwrap();
-            let new_namespace2 = Namespace::new("namespace2").unwrap();
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+                namespace: new_namespace1.to_string(),
             };
             // Fail, no fee at all
             let res = execute_as(deps.as_mut(), TEST_OWNER, msg.clone());
@@ -759,7 +759,7 @@ mod test {
                     "Invalid fee payment sent. Expected {}, sent {:?}",
                     Coin {
                         denom: one_namespace_fee.denom.clone(),
-                        amount: one_namespace_fee.amount * Uint128::from(2u128),
+                        amount: one_namespace_fee.amount,
                     },
                     Vec::<Coin>::new()
                 ))));
@@ -773,13 +773,13 @@ mod test {
                     "Invalid fee payment sent. Expected {}, sent {:?}",
                     Coin {
                         denom: one_namespace_fee.denom.clone(),
-                        amount: one_namespace_fee.amount * Uint128::from(2u128),
+                        amount: one_namespace_fee.amount,
                     },
                     sent_coins
                 ))));
 
             // Success
-            let sent_coins = coins(12, "ujunox");
+            let sent_coins = coins(6, "ujunox");
             let res = execute_as_with_funds(deps.as_mut(), TEST_OWNER, msg, &sent_coins);
             assert_that!(&res)
                 .is_ok()
@@ -798,10 +798,9 @@ mod test {
             deps.querier = mock_manager_querier().build();
             mock_init_with_account(deps.as_mut(), true)?;
             let new_namespace1 = Namespace::new("namespace1").unwrap();
-            let new_namespace2 = Namespace::new("namespace2").unwrap();
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+                namespace: new_namespace1.to_string(),
             };
             let res = execute_as(deps.as_mut(), TEST_OTHER, msg);
             assert_that!(&res)
@@ -818,17 +817,28 @@ mod test {
             let mut deps = mock_dependencies();
             deps.querier = mock_manager_querier().build();
             mock_init_with_account(deps.as_mut(), true)?;
+            // create second account
+            execute_as(
+                deps.as_mut(),
+                TEST_ACCOUNT_FACTORY,
+                ExecuteMsg::AddAccount {
+                    account_id: 2,
+                    account_base: AccountBase {
+                        manager: Addr::unchecked(TEST_MANAGER),
+                        proxy: Addr::unchecked(TEST_PROXY),
+                    },
+                },
+            )?;
             let new_namespace1 = Namespace::new("namespace1")?;
-            let new_namespace2 = Namespace::new("namespace2")?;
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+                namespace: new_namespace1.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
-            let msg = ExecuteMsg::ClaimNamespaces {
-                account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string()],
+            let msg = ExecuteMsg::ClaimNamespace {
+                account_id: 2,
+                namespace: new_namespace1.to_string(),
             };
             let res = execute_as(deps.as_mut(), TEST_OWNER, msg);
             assert_that!(&res)
@@ -884,9 +894,9 @@ mod test {
             )?;
 
             // Attempt to claim the abstract namespace with account 1
-            let claim_abstract_msg = ExecuteMsg::ClaimNamespaces {
+            let claim_abstract_msg = ExecuteMsg::ClaimNamespace {
                 account_id: 1,
-                namespaces: vec![Namespace::try_from(ABSTRACT_NAMESPACE)?.to_string()],
+                namespace: ABSTRACT_NAMESPACE.to_string(),
             };
             let res = execute_as(deps.as_mut(), TEST_OWNER, claim_abstract_msg);
             assert_that!(&res)
@@ -895,70 +905,6 @@ mod test {
                     namespace: Namespace::try_from("abstract")?.to_string(),
                     id: ABSTRACT_ACCOUNT_ID,
                 });
-            Ok(())
-        }
-    }
-
-    mod update_namespace_limit {
-        use super::*;
-
-        #[test]
-        fn only_admin() -> VersionControlTestResult {
-            let mut deps = mock_dependencies();
-            mock_init(deps.as_mut())?;
-
-            let msg = ExecuteMsg::UpdateConfig {
-                allow_direct_module_registration: None,
-                namespace_limit: Some(100),
-                namespace_registration_fee: None,
-            };
-
-            let res = execute_as(deps.as_mut(), TEST_OTHER, msg);
-            assert_that!(&res)
-                .is_err()
-                .is_equal_to(&VCError::Ownership(OwnershipError::NotOwner));
-
-            Ok(())
-        }
-
-        #[test]
-        fn updates_limit() -> VersionControlTestResult {
-            let mut deps = mock_dependencies();
-            mock_init(deps.as_mut())?;
-
-            let msg = ExecuteMsg::UpdateConfig {
-                allow_direct_module_registration: None,
-                namespace_limit: Some(100),
-                namespace_registration_fee: None,
-            };
-
-            let res = execute_as_admin(deps.as_mut(), msg);
-            assert_that!(&res).is_ok();
-
-            assert_that!(CONFIG.load(&deps.storage).unwrap().namespace_limit).is_equal_to(100);
-
-            Ok(())
-        }
-
-        #[test]
-        fn no_decrease() -> VersionControlTestResult {
-            let mut deps = mock_dependencies();
-            mock_init(deps.as_mut())?;
-
-            let msg = ExecuteMsg::UpdateConfig {
-                allow_direct_module_registration: None,
-                namespace_limit: Some(0),
-                namespace_registration_fee: None,
-            };
-
-            let res = execute_as_admin(deps.as_mut(), msg);
-            assert_that!(&res)
-                .is_err()
-                .is_equal_to(VCError::DecreaseNamespaceLimit {
-                    current: 10,
-                    limit: 0,
-                });
-
             Ok(())
         }
     }
@@ -973,7 +919,6 @@ mod test {
 
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: Some(false),
-                namespace_limit: None,
                 namespace_registration_fee: None,
             };
 
@@ -986,20 +931,25 @@ mod test {
         }
 
         #[test]
-        fn updates_limit() -> VersionControlTestResult {
+        fn direct_registration() -> VersionControlTestResult {
             let mut deps = mock_dependencies();
             mock_init(deps.as_mut())?;
 
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: Some(false),
-                namespace_limit: None,
                 namespace_registration_fee: None,
             };
 
             let res = execute_as_admin(deps.as_mut(), msg);
             assert_that!(&res).is_ok();
 
-            assert_that!(CONFIG.load(&deps.storage).unwrap().namespace_limit).is_equal_to(10);
+            assert_that!(
+                CONFIG
+                    .load(&deps.storage)
+                    .unwrap()
+                    .allow_direct_module_registration
+            )
+            .is_equal_to(false);
             assert_that!(
                 CONFIG
                     .load(&deps.storage)
@@ -1023,7 +973,6 @@ mod test {
 
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration: None,
-                namespace_limit: None,
                 namespace_registration_fee: Some(Coin {
                     denom: "ujunox".to_string(),
                     amount: Uint128::one(),
@@ -1034,37 +983,6 @@ mod test {
             assert_that!(&res)
                 .is_err()
                 .is_equal_to(&VCError::Ownership(OwnershipError::NotOwner));
-
-            Ok(())
-        }
-
-        #[test]
-        fn updates_limit() -> VersionControlTestResult {
-            let mut deps = mock_dependencies();
-            mock_init(deps.as_mut())?;
-
-            let new_fee = Coin {
-                denom: "ujunox".to_string(),
-                amount: Uint128::one(),
-            };
-
-            let msg = ExecuteMsg::UpdateConfig {
-                allow_direct_module_registration: None,
-                namespace_limit: None,
-                namespace_registration_fee: Some(new_fee.clone()),
-            };
-
-            let res = execute_as_admin(deps.as_mut(), msg);
-            assert_that!(&res).is_ok();
-
-            assert_that!(CONFIG.load(&deps.storage).unwrap().namespace_limit).is_equal_to(10);
-            assert_that!(
-                CONFIG
-                    .load(&deps.storage)
-                    .unwrap()
-                    .namespace_registration_fee
-            )
-            .is_equal_to(new_fee);
 
             Ok(())
         }
@@ -1089,16 +1007,11 @@ mod test {
             mock_init_with_account(deps.as_mut(), true)?;
             let new_namespace1 = Namespace::new("namespace1").unwrap();
             let new_namespace2 = Namespace::new("namespace2").unwrap();
-            let new_namespace3 = Namespace::new("namespace3").unwrap();
 
             // add namespaces
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![
-                    new_namespace1.to_string(),
-                    new_namespace2.to_string(),
-                    new_namespace3.to_string(),
-                ],
+                namespace: new_namespace1.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1111,24 +1024,25 @@ mod test {
             let exists = namespaces_info().has(&deps.storage, &new_namespace1);
             assert_that!(exists).is_equal_to(false);
 
+            let msg = ExecuteMsg::ClaimNamespace {
+                account_id: TEST_ACCOUNT_ID,
+                namespace: new_namespace2.to_string(),
+            };
+            execute_as(deps.as_mut(), TEST_OWNER, msg)?;
+
             // remove as owner
             let msg = ExecuteMsg::RemoveNamespaces {
-                namespaces: vec![new_namespace2.to_string(), new_namespace3.to_string()],
+                namespaces: vec![new_namespace2.to_string()],
             };
             let res = execute_as(deps.as_mut(), TEST_OWNER, msg);
             assert_that!(&res).is_ok();
             let exists = namespaces_info().has(&deps.storage, &new_namespace2);
             assert_that!(exists).is_equal_to(false);
-            let exists = namespaces_info().has(&deps.storage, &new_namespace3);
-            assert_that!(exists).is_equal_to(false);
             assert_eq!(
                 res.unwrap().events[0].attributes[2],
                 attr(
                     "namespaces",
-                    format!(
-                        "({}, {}),({}, {})",
-                        new_namespace2, TEST_ACCOUNT_ID, new_namespace3, TEST_ACCOUNT_ID
-                    ),
+                    format!("({}, {})", new_namespace2, TEST_ACCOUNT_ID,),
                 )
             );
 
@@ -1141,12 +1055,11 @@ mod test {
             deps.querier = mock_manager_querier().build();
             mock_init_with_account(deps.as_mut(), true)?;
             let new_namespace1 = Namespace::new("namespace1")?;
-            let new_namespace2 = Namespace::new("namespace2")?;
 
             // add namespaces
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+                namespace: new_namespace1.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1201,10 +1114,9 @@ mod test {
 
             // add namespaces
             let new_namespace1 = Namespace::new("namespace1")?;
-            let new_namespace2 = Namespace::new("namespace2")?;
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![new_namespace1.to_string(), new_namespace2.to_string()],
+                namespace: new_namespace1.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1231,6 +1143,7 @@ mod test {
     }
 
     mod propose_modules {
+        use abstract_core::objects::fee::FixedFee;
         use abstract_core::objects::module_reference::ModuleReference;
         use abstract_core::AbstractError;
         use abstract_testing::prelude::TEST_MODULE_ID;
@@ -1287,9 +1200,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
 
@@ -1331,9 +1244,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
 
@@ -1369,9 +1282,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
 
@@ -1394,9 +1307,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
             // add modules
@@ -1441,9 +1354,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
             // add modules
@@ -1485,9 +1398,9 @@ mod test {
             let rm_module = test_module();
 
             // add namespaces
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![rm_module.namespace.to_string()],
+                namespace: rm_module.namespace.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1525,9 +1438,9 @@ mod test {
             let rm_module = test_module();
 
             // add namespaces as the account owner
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![rm_module.namespace.to_string()],
+                namespace: rm_module.namespace.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1561,9 +1474,9 @@ mod test {
             let rm_module = test_module();
 
             // add namespaces as the owner
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![rm_module.namespace.to_string()],
+                namespace: rm_module.namespace.to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1596,9 +1509,9 @@ mod test {
             mock_init_with_account(deps.as_mut(), true)?;
 
             // add namespaces
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec!["namespace".to_string()],
+                namespace: "namespace".to_string(),
             };
             execute_as(deps.as_mut(), TEST_OWNER, msg)?;
 
@@ -1743,9 +1656,9 @@ mod test {
     }
 
     fn claim_test_namespace_as_owner(deps: DepsMut) -> VersionControlTestResult {
-        let msg = ExecuteMsg::ClaimNamespaces {
+        let msg = ExecuteMsg::ClaimNamespace {
             account_id: TEST_ACCOUNT_ID,
-            namespaces: vec![TEST_NAMESPACE.to_string()],
+            namespace: TEST_NAMESPACE.to_string(),
         };
         execute_as(deps, TEST_OWNER, msg)?;
         Ok(())

--- a/contracts/native/version-control/src/commands.rs
+++ b/contracts/native/version-control/src/commands.rs
@@ -953,7 +953,7 @@ mod test {
                 CONFIG
                     .load(&deps.storage)
                     .unwrap()
-                    .allow_direct_module_registration
+                    .allow_direct_module_registration_and_updates
             )
             .is_equal_to(false);
             assert_that!(
@@ -994,7 +994,7 @@ mod test {
         }
 
         #[test]
-        fn updates_limit() -> VersionControlTestResult {
+        fn updates_fee() -> VersionControlTestResult {
             let mut deps = mock_dependencies();
             mock_init(deps.as_mut())?;
 
@@ -1005,14 +1005,12 @@ mod test {
 
             let msg = ExecuteMsg::UpdateConfig {
                 allow_direct_module_registration_and_updates: None,
-                namespace_limit: None,
                 namespace_registration_fee: Some(new_fee.clone()),
             };
 
             let res = execute_as_admin(deps.as_mut(), msg);
             assert_that!(&res).is_ok();
 
-            assert_that!(CONFIG.load(&deps.storage).unwrap().namespace_limit).is_equal_to(10);
             assert_that!(
                 CONFIG
                     .load(&deps.storage)
@@ -1266,9 +1264,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
 
@@ -1306,9 +1304,9 @@ mod test {
             execute_as(
                 deps.as_mut(),
                 TEST_OWNER,
-                ExecuteMsg::ClaimNamespaces {
+                ExecuteMsg::ClaimNamespace {
                     account_id: TEST_ACCOUNT_ID,
-                    namespaces: vec![new_module.namespace.to_string()],
+                    namespace: new_module.namespace.to_string(),
                 },
             )?;
 

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -44,7 +44,6 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
 
     let InstantiateMsg {
         allow_direct_module_registration,
-        namespace_limit,
         namespace_registration_fee,
     } = msg;
 
@@ -52,7 +51,6 @@ pub fn instantiate(deps: DepsMut, _env: Env, info: MessageInfo, msg: Instantiate
         deps.storage,
         &Config {
             allow_direct_module_registration: allow_direct_module_registration.unwrap_or(false),
-            namespace_limit,
             namespace_registration_fee: namespace_registration_fee.unwrap_or(Coin {
                 denom: "none".to_string(),
                 amount: Uint128::zero(),
@@ -89,10 +87,10 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
             namespace,
             monetization,
         } => set_module_monetization(deps, info, module_name, namespace, monetization),
-        ExecuteMsg::ClaimNamespaces {
+        ExecuteMsg::ClaimNamespace {
+            namespace,
             account_id,
-            namespaces,
-        } => claim_namespaces(deps, info, account_id, namespaces),
+        } => claim_namespace(deps, info, account_id, namespace),
         ExecuteMsg::RemoveNamespaces { namespaces } => remove_namespaces(deps, info, namespaces),
         ExecuteMsg::AddAccount {
             account_id,
@@ -100,13 +98,11 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> V
         } => add_account(deps, info, account_id, base),
         ExecuteMsg::UpdateConfig {
             allow_direct_module_registration,
-            namespace_limit,
             namespace_registration_fee,
         } => update_config(
             deps,
             info,
             allow_direct_module_registration,
-            namespace_limit,
             namespace_registration_fee,
         ),
         ExecuteMsg::SetFactory { new_factory } => set_factory(deps, info, new_factory),

--- a/contracts/native/version-control/src/contract.rs
+++ b/contracts/native/version-control/src/contract.rs
@@ -139,17 +139,12 @@ pub fn query(deps: Deps, _env: Env, msg: QueryMsg) -> VCResult<Binary> {
             limit,
             filter,
         )?),
-        QueryMsg::NamespaceList {
-            filter,
-            start_after,
-            limit,
-        } => {
+        QueryMsg::NamespaceList { start_after, limit } => {
             let start_after = start_after.map(Namespace::try_from).transpose()?;
             to_binary(&queries::handle_namespace_list_query(
                 deps,
                 start_after,
                 limit,
-                filter,
             )?)
         }
         QueryMsg::Ownership {} => to_binary(&query_ownership!(deps)?),

--- a/contracts/native/version-control/src/lib.rs
+++ b/contracts/native/version-control/src/lib.rs
@@ -21,7 +21,6 @@ mod testing {
             info,
             version_control::InstantiateMsg {
                 allow_direct_module_registration: Some(true),
-                namespace_limit: 10,
                 namespace_registration_fee: None,
             },
         )

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -4,7 +4,7 @@ use abstract_core::{
     objects::module::{ModuleStatus, Monetization},
     version_control::{
         state::{MODULE_MONETIZATION, PENDING_MODULES},
-        ModuleConfiguration, NamespaceFilter, NamespaceResponse,
+        ModuleConfiguration, NamespaceResponse,
     },
 };
 use abstract_sdk::core::{
@@ -195,7 +195,6 @@ pub fn handle_namespace_list_query(
     deps: Deps,
     start_after: Option<Namespace>,
     limit: Option<u8>,
-    _filter: Option<NamespaceFilter>,
 ) -> StdResult<NamespaceListResponse> {
     let start_bound = start_after.as_ref().map(Bound::exclusive);
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;

--- a/contracts/native/version-control/src/queries.rs
+++ b/contracts/native/version-control/src/queries.rs
@@ -195,27 +195,15 @@ pub fn handle_namespace_list_query(
     deps: Deps,
     start_after: Option<Namespace>,
     limit: Option<u8>,
-    filter: Option<NamespaceFilter>,
+    _filter: Option<NamespaceFilter>,
 ) -> StdResult<NamespaceListResponse> {
     let start_bound = start_after.as_ref().map(Bound::exclusive);
     let limit = limit.unwrap_or(DEFAULT_LIMIT).min(MAX_LIMIT) as usize;
 
-    let NamespaceFilter { account_id } = filter.unwrap_or_default();
-
-    let namespaces = if let Some(account_id) = account_id {
-        namespaces_info()
-            .idx
-            .account_id
-            .prefix(account_id)
-            .range(deps.storage, start_bound, None, Order::Ascending)
-            .take(limit)
-            .collect::<StdResult<Vec<_>>>()?
-    } else {
-        namespaces_info()
-            .range(deps.storage, start_bound, None, Order::Ascending)
-            .take(limit)
-            .collect::<StdResult<Vec<_>>>()?
-    };
+    let namespaces = namespaces_info()
+        .range(deps.storage, start_bound, None, Order::Ascending)
+        .take(limit)
+        .collect::<StdResult<Vec<_>>>()?;
 
     Ok(NamespaceListResponse { namespaces })
 }
@@ -350,7 +338,6 @@ mod test {
             info,
             InstantiateMsg {
                 allow_direct_module_registration: Some(true),
-                namespace_limit: 10,
                 namespace_registration_fee: None,
             },
         )?;
@@ -407,9 +394,9 @@ mod test {
         use cosmwasm_std::from_binary;
 
         fn add_namespace(deps: DepsMut, namespace: &str) {
-            let msg = ExecuteMsg::ClaimNamespaces {
+            let msg = ExecuteMsg::ClaimNamespace {
                 account_id: TEST_ACCOUNT_ID,
-                namespaces: vec![namespace.to_string()],
+                namespace: namespace.to_string(),
             };
 
             let res = execute_as_admin(deps, msg);
@@ -523,24 +510,26 @@ mod test {
     use cosmwasm_std::from_binary;
 
     /// Add namespaces
-    fn add_namespaces(deps: DepsMut, namespaces: Vec<String>, account_id: u32, sender: &str) {
-        let msg = ExecuteMsg::ClaimNamespaces {
-            account_id,
-            namespaces,
-        };
+    fn add_namespaces(mut deps: DepsMut, acc_and_namespace: Vec<(u32, &str)>, sender: &str) {
+        for (account_id, namespace) in acc_and_namespace {
+            let msg = ExecuteMsg::ClaimNamespace {
+                account_id,
+                namespace: namespace.to_string(),
+            };
 
-        let res = execute_as(deps, sender, msg);
-        assert_that!(&res).is_ok();
+            let res = execute_as(deps.branch(), sender, msg);
+            assert_that!(&res).is_ok();
+        }
     }
 
     /// Add the provided modules to the version control
-    fn propose_modules(deps: DepsMut, new_module_infos: Vec<ModuleInfo>) {
+    fn propose_modules(deps: DepsMut, new_module_infos: Vec<ModuleInfo>, sender: &str) {
         let modules = new_module_infos
             .into_iter()
             .map(|info| (info, ModuleReference::App(0)))
             .collect();
         let add_msg = ExecuteMsg::ProposeModules { modules };
-        let res = execute_as_admin(deps, add_msg);
+        let res = execute_as(deps, sender, add_msg);
         assert_that!(&res).is_ok();
     }
 
@@ -557,22 +546,26 @@ mod test {
     fn init_with_mods(mut deps: DepsMut) {
         mock_init_with_account(deps.branch()).unwrap();
 
-        let namespaces = vec!["cw-plus".to_string(), "4t2".to_string()];
-        add_namespaces(deps.branch(), namespaces, TEST_ACCOUNT_ID, TEST_ADMIN);
+        add_namespaces(
+            deps.branch(),
+            vec![(TEST_ACCOUNT_ID, "cw-plus")],
+            TEST_ADMIN,
+        );
+        add_namespaces(deps.branch(), vec![(2, "4t2")], TEST_OTHER);
 
         let cw_mods = vec![
             ModuleInfo::from_id("cw-plus:module1", ModuleVersion::Version("0.1.2".into())).unwrap(),
             ModuleInfo::from_id("cw-plus:module2", ModuleVersion::Version("0.1.2".into())).unwrap(),
             ModuleInfo::from_id("cw-plus:module3", ModuleVersion::Version("0.1.2".into())).unwrap(),
         ];
-        propose_modules(deps.branch(), cw_mods);
+        propose_modules(deps.branch(), cw_mods, TEST_ADMIN);
 
         let fortytwo_mods = vec![
             ModuleInfo::from_id("4t2:module1", ModuleVersion::Version("0.1.2".into())).unwrap(),
             ModuleInfo::from_id("4t2:module2", ModuleVersion::Version("0.1.2".into())).unwrap(),
             ModuleInfo::from_id("4t2:module3", ModuleVersion::Version("0.1.2".into())).unwrap(),
         ];
-        propose_modules(deps, fortytwo_mods);
+        propose_modules(deps, fortytwo_mods, TEST_OTHER);
     }
 
     mod modules {
@@ -690,7 +683,7 @@ mod test {
                 ModuleInfo::from_id("cw-plus:module5", ModuleVersion::Version("0.1.2".into()))
                     .unwrap(),
             ];
-            propose_modules(deps.as_mut(), cw_mods);
+            propose_modules(deps.as_mut(), cw_mods, TEST_ADMIN);
             yank_module(
                 deps.as_mut(),
                 ModuleInfo::from_id("cw-plus:module4", ModuleVersion::Version("0.1.2".into()))
@@ -739,7 +732,7 @@ mod test {
                 ModuleInfo::from_id("cw-plus:module5", ModuleVersion::Version("0.1.2".into()))
                     .unwrap(),
             ];
-            propose_modules(deps.as_mut(), cw_mods);
+            propose_modules(deps.as_mut(), cw_mods, TEST_ADMIN);
             yank_module(
                 deps.as_mut(),
                 ModuleInfo::from_id("cw-plus:module4", ModuleVersion::Version("0.1.2".into()))
@@ -786,25 +779,17 @@ mod test {
             mock_init_with_account(deps.as_mut()).unwrap();
             add_namespaces(
                 deps.as_mut(),
-                vec![
-                    "cw-plus".to_string(),
-                    "aoeu".to_string(),
-                    "snth".to_string(),
-                ],
-                TEST_ACCOUNT_ID,
+                vec![(TEST_ACCOUNT_ID, "cw-plus")],
                 TEST_ADMIN,
             );
-            let cw_mods = vec![
-                ModuleInfo::from_id("cw-plus:module1", ModuleVersion::Version("0.1.2".into()))
-                    .unwrap(),
-                ModuleInfo::from_id("aoeu:module2", ModuleVersion::Version("0.1.2".into()))
-                    .unwrap(),
-                ModuleInfo::from_id("snth:module3", ModuleVersion::Version("0.1.2".into()))
-                    .unwrap(),
-            ];
-            propose_modules(deps.as_mut(), cw_mods);
+            let cw_mods = vec![ModuleInfo::from_id(
+                "cw-plus:module1",
+                ModuleVersion::Version("0.1.2".into()),
+            )
+            .unwrap()];
+            propose_modules(deps.as_mut(), cw_mods, TEST_ADMIN);
 
-            let filtered_namespace = "dne".to_string();
+            let filtered_namespace = "cw-plus".to_string();
 
             let filter = ModuleFilter {
                 namespace: Some(filtered_namespace),
@@ -817,7 +802,7 @@ mod test {
 
             assert_that!(res).is_ok().map(|res| {
                 let ModulesListResponse { modules } = from_binary(res).unwrap();
-                assert_that!(modules).is_empty();
+                assert_that!(modules).has_length(1);
 
                 res
             });
@@ -870,6 +855,7 @@ mod test {
                     ModuleVersion::Version("0.1.3".into()),
                 )
                 .unwrap()],
+                TEST_ADMIN,
             );
 
             let filter = ModuleFilter {
@@ -1017,77 +1003,25 @@ mod test {
         }
     }
 
-    mod list_namespaces {
+    mod query_namespaces {
         use super::*;
 
-        fn filtered_list_msg(filter: NamespaceFilter) -> QueryMsg {
-            QueryMsg::NamespaceList {
-                filter: Some(filter),
-                start_after: None,
-                limit: None,
-            }
-        }
-
         #[test]
-        fn filter_namespaces() {
+        fn namespaces() {
             let mut deps = mock_dependencies();
             deps.querier = mock_manager_querier().build();
             init_with_mods(deps.as_mut());
 
-            // add namespaces as others
-            let namespaces = vec![
-                "other1".to_string(),
-                "other2".to_string(),
-                "other3".to_string(),
-            ];
-            add_namespaces(
-                deps.as_mut(),
-                namespaces.clone(),
-                TEST_OTHER_ACCOUNT_ID,
-                TEST_OTHER,
+            // get for test other account
+            let res = query_helper(
+                deps.as_ref(),
+                QueryMsg::Namespaces {
+                    accounts: vec![TEST_OTHER_ACCOUNT_ID],
+                },
             );
-
-            // get all
-            let list_msg = filtered_list_msg(NamespaceFilter { account_id: None });
-            let res = query_helper(deps.as_ref(), list_msg);
-
             assert_that!(res).is_ok().map(|res| {
-                let NamespaceListResponse { namespaces: resp } = from_binary(res).unwrap();
-                println!("{:?}", resp);
-                assert_that!(resp).has_length(6);
-                res
-            });
-
-            // get by another id
-            let list_msg = filtered_list_msg(NamespaceFilter {
-                account_id: Some(TEST_OTHER_ACCOUNT_ID),
-            });
-            let res = query_helper(deps.as_ref(), list_msg);
-            assert_that!(res).is_ok().map(|res| {
-                let NamespaceListResponse { namespaces: resp } = from_binary(res).unwrap();
-                assert_that!(resp).has_length(3);
-
-                for entry in resp {
-                    assert_that!(namespaces.contains(&entry.0.to_string())).is_equal_to(true);
-                    assert_that!(entry.1).is_equal_to(TEST_OTHER_ACCOUNT_ID);
-                }
-
-                res
-            });
-
-            // get by admin id
-            let list_msg = filtered_list_msg(NamespaceFilter {
-                account_id: Some(TEST_ACCOUNT_ID),
-            });
-            let res = query_helper(deps.as_ref(), list_msg);
-            assert_that!(res).is_ok().map(|res| {
-                let NamespaceListResponse { namespaces: resp } = from_binary(res).unwrap();
-                assert_that!(resp).has_length(2);
-
-                for entry in resp {
-                    assert_that!(entry.1).is_equal_to(TEST_ACCOUNT_ID);
-                }
-
+                let NamespacesResponse { namespaces } = from_binary(res).unwrap();
+                assert_that!(namespaces[0].0.to_string()).is_equal_to("4t2".to_string());
                 res
             });
         }

--- a/docs/src/1_intro.md
+++ b/docs/src/1_intro.md
@@ -73,7 +73,7 @@ let account =
 // Claim the namespace so app can be deployed
 abstr_deployment
     .version_control
-    .claim_namespaces(1, vec!["my-namespace".to_string()])?;
+    .claim_namespace(1, "my-namespace".to_string())?;
 
 // Deploy the app!
 contract.deploy(APP_VERSION.parse()?)?;

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -159,12 +159,6 @@ pub struct ModuleFilter {
     pub status: Option<ModuleStatus>,
 }
 
-/// A NamespaceFilter for [`Namespaces`].
-/// Stub
-#[derive(Default)]
-#[cosmwasm_schema::cw_serde]
-pub struct NamespaceFilter {}
-
 /// Version Control Query Msg
 #[cw_ownable::cw_ownable_query]
 #[cosmwasm_schema::cw_serde]
@@ -201,7 +195,6 @@ pub enum QueryMsg {
     /// Returns [`NamespaceListResponse`]
     #[returns(NamespaceListResponse)]
     NamespaceList {
-        filter: Option<NamespaceFilter>,
         start_after: Option<String>,
         limit: Option<u8>,
     },

--- a/packages/abstract-core/src/native/version_control.rs
+++ b/packages/abstract-core/src/native/version_control.rs
@@ -14,7 +14,6 @@ pub type ModuleMapEntry = (ModuleInfo, ModuleReference);
 #[cosmwasm_schema::cw_serde]
 pub struct Config {
     pub allow_direct_module_registration: bool,
-    pub namespace_limit: u32,
     pub namespace_registration_fee: cosmwasm_std::Coin,
 }
 
@@ -93,7 +92,6 @@ pub struct AccountBase {
 #[cosmwasm_schema::cw_serde]
 pub struct InstantiateMsg {
     pub allow_direct_module_registration: Option<bool>,
-    pub namespace_limit: u32,
     pub namespace_registration_fee: Option<Coin>,
 }
 
@@ -127,9 +125,9 @@ pub enum ExecuteMsg {
         rejects: Vec<ModuleInfo>,
     },
     /// Claim namespaces
-    ClaimNamespaces {
+    ClaimNamespace {
         account_id: AccountId,
-        namespaces: Vec<String>,
+        namespace: String,
     },
     /// Remove namespace claims
     /// Only admin or root user can call this
@@ -145,7 +143,6 @@ pub enum ExecuteMsg {
     /// 2. the number of namespaces an Account can claim
     UpdateConfig {
         allow_direct_module_registration: Option<bool>,
-        namespace_limit: Option<u32>,
         namespace_registration_fee: Option<Coin>,
     },
     /// Sets a new Factory
@@ -163,11 +160,10 @@ pub struct ModuleFilter {
 }
 
 /// A NamespaceFilter for [`Namespaces`].
+/// Stub
 #[derive(Default)]
 #[cosmwasm_schema::cw_serde]
-pub struct NamespaceFilter {
-    pub account_id: Option<AccountId>,
-}
+pub struct NamespaceFilter {}
 
 /// Version Control Query Msg
 #[cw_ownable::cw_ownable_query]

--- a/packages/abstract-interface/src/deployment.rs
+++ b/packages/abstract-interface/src/deployment.rs
@@ -141,7 +141,6 @@ impl<Chain: CwEnv> Abstract<Chain> {
         self.version_control.instantiate(
             &abstract_core::version_control::InstantiateMsg {
                 allow_direct_module_registration: Some(true),
-                namespace_limit: 1,
                 namespace_registration_fee: None,
             },
             Some(sender),


### PR DESCRIPTION
Remove the ability to have multiple namespaces registered by an account.